### PR TITLE
Separate development from release environment

### DIFF
--- a/source/Config.gd
+++ b/source/Config.gd
@@ -361,11 +361,18 @@ func save_config():
 	config.save_config_to_path(get_config_file())
 
 func get_config_dir() -> String:
+	var path : String
 	match FileUtils.get_os_id():
 		OS_ID.WINDOWS:
-			return FileUtils.get_home_dir() + "/RetroHub"
+			path = FileUtils.get_home_dir() + "/RetroHub"
+			if RetroHub._is_dev_env():
+				path += "-Dev"
+			return path
 		_:
-			return FileUtils.get_home_dir() + "/.retrohub"
+			path = FileUtils.get_home_dir() + "/.retrohub"
+			if RetroHub._is_dev_env():
+				path += "-dev"
+	return path
 
 func get_config_file() -> String:
 	return get_config_dir() + "/rh_config.json"

--- a/source/RetroHub.gd
+++ b/source/RetroHub.gd
@@ -96,6 +96,9 @@ func is_input_echo() -> bool:
 func is_main_app() -> bool:
 	return true
 
+func _is_dev_env() -> bool:
+	return not OS.has_feature("standalone")
+
 func quit():
 	RetroHubConfig.save_config()
 	get_tree().quit()


### PR DESCRIPTION
When in development, RetroHub will now use `RetroHub-Dev` (Windows) / `.retrohub-dev` (macOS/Linux) folders instead.

This prevents modification and corruption to existing user setups.

Closes #39 