### PR TITLE
Refactor system field in game data

### DIFF
--- a/assets/icons/app/retrohub_logo_1024px_draft.png.import
+++ b/assets/icons/app/retrohub_logo_1024px_draft.png.import
@@ -1,0 +1,35 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/retrohub_logo_1024px_draft.png-dcd5703e4d98eb7e314b4e16d4cc847d.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://assets/icons/app/retrohub_logo_1024px_draft.png"
+dest_files=[ "res://.import/retrohub_logo_1024px_draft.png-dcd5703e4d98eb7e314b4e16d4cc847d.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+process/normal_map_invert_y=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/assets/icons/app/retrohub_logo_256px_alt.png.import
+++ b/assets/icons/app/retrohub_logo_256px_alt.png.import
@@ -1,0 +1,35 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/retrohub_logo_256px_alt.png-e4a4f62211c272d65923e92e4ddfb053.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://assets/icons/app/retrohub_logo_256px_alt.png"
+dest_files=[ "res://.import/retrohub_logo_256px_alt.png-e4a4f62211c272d65923e92e4ddfb053.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+process/normal_map_invert_y=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/assets/icons/app/retrohub_logo_256px_draft.png.import
+++ b/assets/icons/app/retrohub_logo_256px_draft.png.import
@@ -1,0 +1,35 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/retrohub_logo_256px_draft.png-b7062a0e7d525e17ce8dbaa3dd3dd619.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://assets/icons/app/retrohub_logo_256px_draft.png"
+dest_files=[ "res://.import/retrohub_logo_256px_draft.png-b7062a0e7d525e17ce8dbaa3dd3dd619.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+process/normal_map_invert_y=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/assets/icons/app/retrohub_logo_4096px_draft.png.import
+++ b/assets/icons/app/retrohub_logo_4096px_draft.png.import
@@ -1,0 +1,35 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/retrohub_logo_4096px_draft.png-a378f55d3e6812c4b7ed29e96d5fd4d2.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://assets/icons/app/retrohub_logo_4096px_draft.png"
+dest_files=[ "res://.import/retrohub_logo_4096px_draft.png-a378f55d3e6812c4b7ed29e96d5fd4d2.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+process/normal_map_invert_y=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/scenes/root/popups/scraper/ScraperPopup.gd
+++ b/scenes/root/popups/scraper/ScraperPopup.gd
@@ -127,12 +127,12 @@ func clear_game_entries():
 
 func populate_game_entries():
 	for game_data in game_list_arr:
-		if not scene_entry_list.has(game_data.system_name):
+		if not scene_entry_list.has(game_data.system.name):
 			var scene_entry = system_entry_scene.instance()
 			n_game_entries.add_child(scene_entry)
-			scene_entry.system_name = RetroHubConfig.systems[game_data.system_name].fullname
-			scene_entry_list[game_data.system_name] = scene_entry
-		var game_entry = scene_entry_list[game_data.system_name].add_game_entry(game_data, button_group)
+			scene_entry.system_name = game_data.system.fullname
+			scene_entry_list[game_data.system] = scene_entry
+		var game_entry = scene_entry_list[game_data.system].add_game_entry(game_data, button_group)
 		game_entry.connect("game_selected", self, "_on_game_entry_selected")
 		game_entry_list.push_back(game_entry)
 	num_games_pending = game_list_arr.size()

--- a/scenes/root/popups/scraping_game_picker/ScrapingGamePickerPopup.gd
+++ b/scenes/root/popups/scraping_game_picker/ScrapingGamePickerPopup.gd
@@ -25,9 +25,9 @@ func _on_ScrapingGamePickerPopup_about_to_show():
 	for system in RetroHubConfig.systems.values():
 		var item = n_game_tree.create_item(root)
 		set_item_settings(item, system.fullname)
-		systems_items[system.name] = item
+		systems_items[system] = item
 	for game in RetroHubConfig.games:
-		var item = n_game_tree.create_item(systems_items[game.system_name])
+		var item = n_game_tree.create_item(systems_items[game.system])
 		set_item_settings(item, game.path.get_file())
 		item.set_metadata(0, game)
 

--- a/source/Config.gd
+++ b/source/Config.gd
@@ -127,7 +127,7 @@ func load_system_gamelists_files(folder_path: String, system_name: String):
 
 				var game := RetroHubGameData.new()
 				game.path = full_path
-				game.system_name = system_name
+				game.system = systems[system_name]
 				# Check if metadata exists, in the form of a .json file
 				var metadata_path = get_game_data_path_from_file(system_name, full_path)
 				if dir.file_exists(metadata_path):
@@ -187,7 +187,7 @@ func get_game_data_path_from_file(system_name: String, file_name: String):
 	return get_gamelists_dir() + "/" + system_name + "/" + file_name.get_file().trim_suffix(file_name.get_extension()) + "json"
 
 func save_game_data(game_data: RetroHubGameData) -> bool:
-	var metadata_path = get_game_data_path_from_file(game_data.system_name, game_data.path)
+	var metadata_path = get_game_data_path_from_file(game_data.system.name, game_data.path)
 	FileUtils.ensure_path(metadata_path)
 	var game_data_raw = {}
 	game_data_raw["name"] = game_data.name

--- a/source/Media.gd
+++ b/source/Media.gd
@@ -190,7 +190,7 @@ func scrape_game_by_hash(game_data: RetroHubGameData) -> void:
 		return
 
 	var file = File.new()
-	var system_id = get_ss_system_mapping(game_data.system_name)
+	var system_id = get_ss_system_mapping(game_data.system.name)
 	var rom_name = game_data.path.get_file()
 	var md5 = file.get_md5(game_data.path)
 	file.open(game_data.path, File.READ)
@@ -281,7 +281,7 @@ func clear_cache():
 	_req_body = PoolByteArray()
 
 func scrape_game_by_search(game_data: RetroHubGameData, search_term: String) -> void:
-	var system_id = get_ss_system_mapping(game_data.system_name)
+	var system_id = get_ss_system_mapping(game_data.system.name)
 
 	var header_data = {
 		"devid": ss_get_api_keys(ss_api_user, false),
@@ -440,7 +440,7 @@ func _process_raw_game_media_data(json: Dictionary, game_data: RetroHubGameData,
 	if not res.empty():
 		if download_locally:
 			var local_filename = RetroHubConfig.get_gamemedia_dir() + "/" + \
-								game_data.system_name + "/" + media_type + \
+								game_data.system.name + "/" + media_type + \
 								"/" + game_data.path.get_file().get_basename()
 			FileUtils.ensure_path(local_filename)
 			download_file = local_filename + "." + res["format"]
@@ -465,7 +465,7 @@ func retrieve_media_data(game_data: RetroHubGameData) -> RetroHubGameMediaData:
 		return null
 	var game_media_data := RetroHubGameMediaData.new()
 
-	var media_path = RetroHubConfig.get_gamemedia_dir() + "/" + game_data.system_name
+	var media_path = RetroHubConfig.get_gamemedia_dir() + "/" + game_data.system.name
 	var game_path = game_data.path.get_file().get_basename()
 
 	var image := Image.new()

--- a/source/RetroHub.gd
+++ b/source/RetroHub.gd
@@ -110,7 +110,7 @@ func launch_game() -> void:
 
 	launched_game_data = curr_game_data
 	_update_game_statistics()
-	launched_system_data = RetroHubConfig.systems[launched_game_data.system_name]
+	launched_system_data = launched_game_data.system
 	print("Launching game ", launched_game_data.name)
 	emit_signal("_game_loaded", launched_game_data)
 	running_game = true

--- a/source/data/GameData.gd
+++ b/source/data/GameData.gd
@@ -10,7 +10,7 @@ var has_metadata : bool
 var has_media : bool
 
 ## From what system is this game from
-var system_name : String
+var system : RetroHubSystemData
 
 ## Name; will default to `path` if no metadata is present yet
 var name : String

--- a/source/emulators/RetroarchEmulator.gd
+++ b/source/emulators/RetroarchEmulator.gd
@@ -63,4 +63,4 @@ func _init(emulator_raw : Dictionary, game_data : RetroHubGameData, system_cores
 	if not corefile.empty():
 		command = substitute_str(command)
 	else:
-		print("Could not find valid core file for emulator \"%s\"" % game_data.system_name)
+		print("Could not find valid core file for emulator \"%s\"" % game_data.system.name)

--- a/source/importers/EmulationStationImporter.gd
+++ b/source/importers/EmulationStationImporter.gd
@@ -222,7 +222,6 @@ func process_metadata(system: String, dict: Dictionary):
 	var root_path = RetroHubConfig.config.games_dir + "/" + system
 	game_data.has_metadata = true
 	game_data.path = root_path + "/" + dict["path"].substr(2)
-	game_data.system_name = system
 	progress_minor("Converting \"%s\" (\"%s\")" % [game_data.path.get_file(), system])
 	if dict.has("name"):
 		game_data.name = dict["name"]

--- a/source/importers/RetroArchImporter.gd
+++ b/source/importers/RetroArchImporter.gd
@@ -160,7 +160,6 @@ func process_metadata(system: String, dict: Dictionary):
 	var root_path = RetroHubConfig.config.games_dir + "/" + system
 	game_data.has_metadata = true
 	game_data.path = root_path + "/" + dict["path"].substr(2)
-	game_data.system_name = system
 	progress_minor("Converting \"%s\" (\"%s\")" % [game_data.path.get_file(), system])
 	if dict.has("name"):
 		game_data.name = dict["name"]


### PR DESCRIPTION
Game data had a field `system_name` which was the system's identifiable name. This is redundant and wasteful. Now, games have a direct reference to their system data. Not only it saves in memory (Godot copies strings), it also streamlines access to the system data, removing the need to do code like `RetroHubConfig.systems[game_data.system_name].fullname`.

This is a change in core API, so all sub-projects and themes need to be refactored as well.