### PR TITLE
Reduce CPU usage during games

### DIFF
--- a/scenes/game_launched/GameLaunched.gd
+++ b/scenes/game_launched/GameLaunched.gd
@@ -3,6 +3,22 @@ extends CenterContainer
 var game_data : RetroHubGameData setget set_game_data
 var label_text : String
 
+var low_cpu_mode_orig : bool
+var low_cpu_mode_sleep_orig : int
+
+func _enter_tree():
+	low_cpu_mode_orig = OS.low_processor_usage_mode
+	low_cpu_mode_sleep_orig = OS.low_processor_usage_mode_sleep_usec
+
+	OS.low_processor_usage_mode = true
+	# 30 FPS
+	OS.low_processor_usage_mode_sleep_usec = 1000000 / 30
+
+func _exit_tree():
+	# Restore old CPU mode settings
+	OS.low_processor_usage_mode = low_cpu_mode_orig
+	OS.low_processor_usage_mode_sleep_usec = low_cpu_mode_sleep_orig
+
 func _ready():
 	label_text = $Label.text
 


### PR DESCRIPTION
RetroHub is put in low processor mode and running at a fixed 30FPS while content is running. This reduces CPU usage a lot.

Fixes #56 