### PR TITLE
Make game data information global

### DIFF
--- a/scenes/root/popups/config/GameMetadataEditor.gd
+++ b/scenes/root/popups/config/GameMetadataEditor.gd
@@ -45,7 +45,7 @@ func discard_changes():
 		n_name.text = game_data.name
 		n_description.text = game_data.description
 		n_rating.value = int(game_data.rating * 100)
-		n_release_date.text = game_data.release_date
+		n_release_date.text = RegionUtils.localize_date(game_data.release_date)
 		n_developer.text = game_data.developer
 		n_publisher.text = game_data.publisher
 		rating_str = game_data.age_rating
@@ -110,7 +110,7 @@ func save_changes():
 		game_data.name = n_name.text
 		game_data.description = n_description.text
 		game_data.rating = n_rating.value / 100.0
-		game_data.release_date = n_release_date.text
+		game_data.release_date = RegionUtils.globalize_date_str(n_release_date.text)
 		game_data.developer = n_developer.text
 		game_data.publisher = n_publisher.text
 		game_data.age_rating = rating_str

--- a/source/Config.gd
+++ b/source/Config.gd
@@ -71,8 +71,6 @@ func load_config_file():
 func _on_config_updated(key, old_value, new_value):
 	if key == ConfigData.KEY_GAMES_DIR:
 		load_game_data_files()
-	if key == ConfigData.KEY_DATE_FORMAT:
-		refresh_game_data_dates(old_value)
 
 	emit_signal("config_updated", key, old_value, new_value)
 
@@ -89,15 +87,6 @@ func load_game_data_files():
 		# We are not interested in files, only folders
 		file_name = _dir.get_next()
 	_dir.list_dir_end()
-
-func refresh_game_data_dates(old_format):
-	var date_raw : String
-	for game in games:
-		date_raw = RegionUtils.globalize_date_str(game.release_date, old_format)
-		game.release_date = RegionUtils.localize_date(date_raw)
-		date_raw = RegionUtils.globalize_date_str(game.last_played, old_format)
-		game.last_played = RegionUtils.localize_date(date_raw)
-		emit_signal("game_data_updated", game)
 
 func load_system_gamelists_files(folder_path: String, system_name: String):
 	print("Loading games from directory " + folder_path)
@@ -170,7 +159,7 @@ func fetch_game_data(path: String, game: RetroHubGameData) -> bool:
 	game.name = data["name"]
 	game.description = data["description"]
 	game.rating = data["rating"]
-	game.release_date = RegionUtils.localize_date(data["release_date"] as String)
+	game.release_date = data["release_date"]
 	game.developer = data["developer"]
 	game.publisher = data["publisher"]
 	game.genres = data["genres"]
@@ -178,7 +167,7 @@ func fetch_game_data(path: String, game: RetroHubGameData) -> bool:
 	game.age_rating = data["age_rating"]
 	game.favorite = data["favorite"]
 	game.play_count = data["play_count"]
-	game.last_played = RegionUtils.localize_date(data["last_played"] as String)
+	game.last_played = data["last_played"]
 	game.has_media = data["has_media"]
 
 	return true
@@ -193,7 +182,7 @@ func save_game_data(game_data: RetroHubGameData) -> bool:
 	game_data_raw["name"] = game_data.name
 	game_data_raw["description"] = game_data.description
 	game_data_raw["rating"] = game_data.rating
-	game_data_raw["release_date"] = RegionUtils.globalize_date_str(game_data.release_date)
+	game_data_raw["release_date"] = game_data.release_date
 	game_data_raw["developer"] = game_data.developer
 	game_data_raw["publisher"] = game_data.publisher
 	game_data_raw["genres"] = game_data.genres
@@ -201,7 +190,7 @@ func save_game_data(game_data: RetroHubGameData) -> bool:
 	game_data_raw["age_rating"] = game_data.age_rating
 	game_data_raw["favorite"] = game_data.favorite
 	game_data_raw["play_count"] = game_data.play_count
-	game_data_raw["last_played"] = RegionUtils.globalize_date_str(game_data.last_played)
+	game_data_raw["last_played"] = game_data.last_played
 	game_data_raw["has_media"] = game_data.has_media
 	
 	if _file.open(metadata_path, File.WRITE):

--- a/source/RetroHub.gd
+++ b/source/RetroHub.gd
@@ -134,8 +134,7 @@ func _launch_game_process() -> int:
 
 func _update_game_statistics():
 	var time_dict := Time.get_datetime_dict_from_system()
-	var time_str = RegionUtils.globalize_date_dict(time_dict)
-	launched_game_data.last_played = RegionUtils.localize_date(time_str)
+	launched_game_data.last_played = RegionUtils.globalize_date_dict(time_dict)
 	launched_game_data.play_count += 1
 	RetroHubConfig.save_game_data(launched_game_data)
 

--- a/source/data/GameData.gd
+++ b/source/data/GameData.gd
@@ -25,7 +25,8 @@ var description : String
 ## Rating, in the range [0.0, 1.0]
 var rating : float
 
-## Release date, already pre-formatted to user's region.
+## Release date in ISO8601 format. Use RegionUtils.localize_date(...) to show this
+## information correctly according to the user's preferences.
 var release_date : String
 
 ## Developer name
@@ -52,6 +53,7 @@ var favorite : bool
 ## How many times with game was launched/played
 var play_count : int
 
-## Last date this game was played, already pre-formatted to user's region.
-## May be "null" if game hasn't been played yet
+## Last date this game was played, in ISO8601 format. Use RegionUtils.localize_date(...)
+## to show this information correctly according to the user's preferences.
+## May be equal to "null" if game hasn't been played yet
 var last_played : String

--- a/source/importers/EmulationStationImporter.gd
+++ b/source/importers/EmulationStationImporter.gd
@@ -230,7 +230,7 @@ func process_metadata(system: String, dict: Dictionary):
 	if dict.has("rating"):
 		game_data.rating = float(dict["rating"])
 	if dict.has("releasedate"):
-		game_data.release_date = RegionUtils.localize_date(dict["releasedate"])
+		game_data.release_date = dict["releasedate"]
 	if dict.has("developer"):
 		game_data.developer = dict["developer"]
 	if dict.has("publisher"):
@@ -247,7 +247,7 @@ func process_metadata(system: String, dict: Dictionary):
 	if dict.has("playcount"):
 		game_data.play_count = dict["playcount"]
 	if dict.has("lastplayed"):
-		game_data.last_played = RegionUtils.localize_date(dict["lastplayed"])
+		game_data.last_played = dict["lastplayed"]
 	if dict.has("favorite"):
 		game_data.favorite = bool(dict["favorite"])
 	var short_path = system + "/" + game_data.path.get_file().get_basename()

--- a/source/scraper/ScreenScraperScraper.gd
+++ b/source/scraper/ScreenScraperScraper.gd
@@ -462,7 +462,7 @@ func _process_raw_game_data(json: Dictionary, game_data: RetroHubGameData):
 	if json.has("note"):
 		game_data.rating = float(json["note"]["text"]) / 20.0
 	if json.has("dates"):
-		game_data.release_date = RegionUtils.localize_date(extract_json_date(extract_json_region(json["dates"])["text"]))
+		game_data.release_date = extract_json_date(extract_json_region(json["dates"])["text"])
 	if json.has("classifications"):
 		game_data.age_rating = extract_json_age_rating(json["classifications"])
 


### PR DESCRIPTION
With this, all fields from `RetroHubGameData` are now global, and need to be manually localized by themes.

Closes #50

This is a change in core API, so all sub-projects and themes need to be refactored as well.