### PR TITLE
Implement async load of media

### DIFF
--- a/source/RetroHub.gd
+++ b/source/RetroHub.gd
@@ -73,6 +73,7 @@ func _load_theme():
 	RetroHubConfig.unload_theme()
 	if not RetroHubConfig.load_theme():
 		return
+	RetroHubMedia._start_thread()
 	emit_signal("_theme_loaded", RetroHubConfig.theme_data)
 	RetroHubConfig.load_theme_config()
 
@@ -112,6 +113,7 @@ func launch_game() -> void:
 	_update_game_statistics()
 	launched_system_data = launched_game_data.system
 	print("Launching game ", launched_game_data.name)
+	RetroHubMedia._stop_thread()
 	emit_signal("_game_loaded", launched_game_data)
 	running_game = true
 	running_game_pid = _launch_game_process()


### PR DESCRIPTION
Themes can now request media asynchronously so they don't block for them. This is a huge boost for app responsiveness when dealing with hundreds of games.

Requests can also be canceled, so themes can optimize I/O even further.

Closes #58 

While this is a change in core API, this doesn't require changes on themes.