### PR TITLE
Refactor user system/emulators files

### DIFF
--- a/addons/controller_icons/plugin.cfg
+++ b/addons/controller_icons/plugin.cfg
@@ -3,5 +3,5 @@
 name="Controller Icons"
 description="Provides icons for all major controllers and keyboard, with automatic icon remapping."
 author="rsubtil"
-version="1.1.1"
+version="1.1.2"
 script="plugin.gd"

--- a/base_config/emulators.json
+++ b/base_config/emulators.json
@@ -1,1221 +1,1219 @@
-{
-	"emulators_list": [
-		{
-			"name": "retroarch",
-			"fullname": "RetroArch",
-			"binpath": [
-				{
-					"windows": [
-						"C:/RetroArch-Win64/retroarch.exe",
-						"C:/RetroArch/retroarch.exe",
-						"~/AppData/Roaming/RetroArch/retroarch.exe",
-						"C:/Program Files/RetroArch-Win64/retroarch.exe",
-						"C:/Program Files/RetroArch/retroarch.exe",
-						"C:/Program Files (x86)/RetroArch-Win64/retroarch.exe",
-						"C:/Program Files (x86)/RetroArch/retroarch.exe",
-						"C:/Program Files (x86)/Steam/steamapps/common/RetroArch/retroarch.exe",
-						"D:/Program Files (x86)/Steam/steamapps/common/RetroArch/retroarch.exe",
-						"C:/Program Files/Steam/steamapps/common/RetroArch/retroarch.exe",
-						"D:/Program Files/Steam/steamapps/common/RetroArch/retroarch.exe"
-					]
-				},
-				{
-					"macos": [
-						"/Applications/RetroArch.app/Contents/MacOS/RetroArch"
-					]
-				},
-				{
-					"linux": [
-						"/bin/retroarch",
-						"/usr/bin/retroarch",
-						"/var/lib/flatpak/exports/bin/org.libretro.RetroArch",
-						"~/.local/share/flatpak/exports/bin/org.libretro.RetroArch",
-						"~/Applications/RetroArch-Linux-x86_64.AppImage",
-						"~/.local/bin/RetroArch-Linux-x86_64.AppImage",
-						"~/bin/RetroArch-Linux-x86_64.AppImage"
-					]
-				}
-			],
-			"corepath": [
-				{
-					"windows": [
-						"{binpath}/../cores"
-					]
-				},
-				{
-					"macos": [
-						"~/Library/Application Support/RetroArch/cores",
-						"/Applications/RetroArch.app/Contents/Resources/cores"
-					]
-				},
-				{
-					"linux": [
-						"~/snap/retroarch/current/.config/retroarch/cores",
-						"~/.var/app/org.libretro.RetroArch/config/retroarch/cores",
-						"~/.config/retroarch/cores",
-						"/usr/lib/x86_64-linux-gnu/libretro",
-						"/usr/lib64/libretro",
-						"/usr/lib/libretro",
-						"/usr/local/lib/libretro",
-						"/usr/pkg/lib/libretro"
-					]
-				}
-			],
-			"cores": [
-				{
-					"name": "atari800",
-					"fullname": "Atari800",
-					"file": [
-						{
-							"windows": "atari800_libretro.dll",
-							"macos": "atari800_libretro.dylib",
-							"linux": "atari800_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "beetle-lynx",
-					"fullname": "Mednafen - Lynx",
-					"file": [
-						{
-							"windows": "mednafen_lynx_libretro.dll",
-							"macos": "mednafen_lynx_libretro.dylib",
-							"linux": "mednafen_lynx_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "beetle-ngp",
-					"fullname": "Mednafen - Neo Geo Pocket",
-					"file": [
-						{
-							"windows": "mednafen_ngp_libretro.dll",
-							"macos": "mednafen_ngp_libretro.dylib",
-							"linux": "mednafen_ngp_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "beetle-pc-fx",
-					"fullname": "Mednafen - PC-FX",
-					"file": [
-						{
-							"windows": "mednafen_pcfx_libretro.dll",
-							"macos": "mednafen_pcfx_libretro.dylib",
-							"linux": "mednafen_pcfx_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "beetle-pce-fast",
-					"fullname": "Mednafen - PC Engine (Fast)",
-					"file": [
-						{
-							"windows": "mednafen_pce_fast_libretro.dll",
-							"macos": "mednafen_pce_fast_libretro.dylib",
-							"linux": "mednafen_pce_fast_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "beetle-psx",
-					"fullname": "Mednafen - PlayStation",
-					"file": [
-						{
-							"windows": "mednafen_psx_libretro.dll",
-							"macos": "mednafen_psx_libretro.dylib",
-							"linux": "mednafen_psx_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "beetle-psx-hw",
-					"fullname": "Mednafen - PlayStation (HW)",
-					"file": [
-						{
-							"windows": "mednafen_psx_hw_libretro.dll",
-							"macos": "mednafen_psx_hw_libretro.dylib",
-							"linux": "mednafen_psx_hw_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "beetle-saturn",
-					"fullname": "Mednafen - Saturn",
-					"file": [
-						{
-							"windows": "mednafen_saturn_libretro.dll",
-							"macos": "mednafen_saturn_libretro.dylib",
-							"linux": "mednafen_saturn_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "beetle-saturn-hw",
-					"fullname": "Mednafen - Saturn (HW)",
-					"file": [
-						{
-							"windows": "mednafen_saturn_hw_libretro.dll",
-							"macos": "mednafen_saturn_hw_libretro.dylib",
-							"linux": "mednafen_saturn_hw_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "beetle-supafaust",
-					"fullname": "Mednafen - SNES (SupaFaust)",
-					"file": [
-						{
-							"windows": "mednafen_supafaust_libretro.dll",
-							"macos": "mednafen_supafaust_libretro.dylib",
-							"linux": "mednafen_supafaust_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "beetle-supergrafx",
-					"fullname": "Mednafen - SuperGrafx",
-					"file": [
-						{
-							"windows": "mednafen_supergrafx_libretro.dll",
-							"macos": "mednafen_supergrafx_libretro.dylib",
-							"linux": "mednafen_supergrafx_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "beetle-vb",
-					"fullname": "Mednafen - Virtual Boy",
-					"file": [
-						{
-							"windows": "mednafen_vb_libretro.dll",
-							"macos": "mednafen_vb_libretro.dylib",
-							"linux": "mednafen_vb_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "beetle-wswan",
-					"fullname": "Mednafen - WonderSwan",
-					"file": [
-						{
-							"windows": "mednafen_wswan_libretro.dll",
-							"macos": "mednafen_wswan_libretro.dylib",
-							"linux": "mednafen_wswan_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "blastem",
-					"fullname": "BlastEm",
-					"file": [
-						{
-							"windows": "blastem_libretro.dll",
-							"macos": "blastem_libretro.dylib",
-							"linux": "blastem_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "bluemsx",
-					"fullname": "blueMSX",
-					"file": [
-						{
-							"windows": "bluemsx_libretro.dll",
-							"macos": "bluemsx_libretro.dylib",
-							"linux": "bluemsx_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "bsnes",
-					"fullname": "bsnes",
-					"file": [
-						{
-							"windows": "bsnes_libretro.dll",
-							"macos": "bsnes_libretro.dylib",
-							"linux": "bsnes_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "bshes-hd",
-					"fullname": "bsnes-hd",
-					"file": [
-						{
-							"windows": "bsnes_hd_beta_libretro.dll",
-							"macos": "bsnes_hd_beta_libretro.dylib",
-							"linux": "bsnes_hd_beta_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "bsnes-mercury-accuracy",
-					"fullname": "bsnes-mercury Accuracy",
-					"file": [
-						{
-							"windows": "bsnes_mercury_accuracy_libretro.dll",
-							"macos": "bsnes_mercury_accuracy_libretro.dylib",
-							"linux": "bsnes_mercury_accuracy_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "caprice32",
-					"fullname": "CaPriCe32",
-					"file": [
-						{
-							"windows": "cap32_libretro.dll",
-							"macos": "cap32_libretro.dylib",
-							"linux": "cap32_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "chailove",
-					"fullname": "ChaiLove",
-					"file": [
-						{
-							"windows": "chailove_libretro.dll",
-							"macos": "chailove_libretro.dylib",
-							"linux": "chailove_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "citra",
-					"fullname": "Citra",
-					"file": [
-						{
-							"windows": "citra_libretro.dll",
-							"macos": "citra_libretro.dylib",
-							"linux": "citra_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "crocods",
-					"fullname": "CrocoDS",
-					"file": [
-						{
-							"windows": "crocods_libretro.dll",
-							"macos": "crocods_libretro.dylib",
-							"linux": "crocods_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "desmume",
-					"fullname": "DeSmuME",
-					"file": [
-						{
-							"windows": "desmume_libretro.dll",
-							"macos": "desmume_libretro.dylib",
-							"linux": "desmume_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "dolphin",
-					"fullname": "Dolphin",
-					"file": [
-						{
-							"windows": "dolphin_libretro.dll",
-							"macos": "dolphin_libretro.dylib",
-							"linux": "dolphin_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "dosbox",
-					"fullname": "DOSBox",
-					"file": [
-						{
-							"windows": "dosbox_libretro.dll",
-							"macos": "dosbox_libretro.dylib",
-							"linux": "dosbox_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "dosboxpure",
-					"fullname": "DOSBox (Pure)",
-					"file": [
-						{
-							"windows": "dosbox_pure_libretro.dll",
-							"macos": "dosbox_pure_libretro.dylib",
-							"linux": "dosbox_pure_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "duckstation",
-					"fullname": "DuckStation",
-					"file": [
-						{
-							"windows": "duckstation_libretro.dll",
-							"macos": "duckstation_libretro.dylib",
-							"linux": "duckstation_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "eightyone",
-					"fullname": "EightyOne",
-					"file": [
-						{
-							"windows": "81_libretro.dll",
-							"macos": "81_libretro.dylib",
-							"linux": "81_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "fba2012",
-					"fullname": "FinalBurn Alpha (2012)",
-					"file": [
-						{
-							"windows": "fbalpha2012_libretro.dll",
-							"macos": "fbalpha2012_libretro.dylib",
-							"linux": "fbalpha2012_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "fbneo",
-					"fullname": "FinalBurn Neo",
-					"file": [
-						{
-							"windows": "fbneo_libretro.dll",
-							"macos": "fbneo_libretro.dylib",
-							"linux": "fbneo_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "fceumm",
-					"fullname": "FCEUmm",
-					"file": [
-						{
-							"windows": "fceumm_libretro.dll",
-							"macos": "fceumm_libretro.dylib",
-							"linux": "fceumm_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "flycast",
-					"fullname": "Flycast",
-					"file": [
-						{
-							"windows": "flycast_libretro.dll",
-							"macos": "flycast_libretro.dylib",
-							"linux": "flycast_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "fmsx",
-					"fullname": "fMSX",
-					"file": [
-						{
-							"windows": "fmsx_libretro.dll",
-							"macos": "fmsx_libretro.dylib",
-							"linux": "fmsx_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "freechaf",
-					"fullname": "FreeChaF",
-					"file": [
-						{
-							"windows": "freechaf_libretro.dll",
-							"macos": "freechaf_libretro.dylib",
-							"linux": "freechaf_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "freeintv",
-					"fullname": "FreeIntV",
-					"file": [
-						{
-							"windows": "freeintv_libretro.dll",
-							"macos": "freeintv_libretro.dylib",
-							"linux": "freeintv_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "frodo",
-					"fullname": "Frodo",
-					"file": [
-						{
-							"windows": "frodo_libretro.dll",
-							"macos": "frodo_libretro.dylib",
-							"linux": "frodo_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "fuse",
-					"fullname": "FUSE",
-					"file": [
-						{
-							"windows": "fuse_libretro.dll",
-							"macos": "fuse_libretro.dylib",
-							"linux": "fuse_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "gambatte",
-					"fullname": "Gambatte",
-					"file": [
-						{
-							"windows": "gambatte_libretro.dll",
-							"macos": "gambatte_libretro.dylib",
-							"linux": "gambatte_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "gearboy",
-					"fullname": "Gearboy",
-					"file": [
-						{
-							"windows": "gearboy_libretro.dll",
-							"macos": "gearboy_libretro.dylib",
-							"linux": "gearboy_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "gearcoleco",
-					"fullname": "GearColeco",
-					"file": [
-						{
-							"windows": "gearcoleco_libretro.dll",
-							"macos": "gearcoleco_libretro.dylib",
-							"linux": "gearcoleco_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "genesis-plus-gx",
-					"fullname": "Genesis Plus GX",
-					"file": [
-						{
-							"windows": "genesis_plus_gx_libretro.dll",
-							"macos": "genesis_plus_gx_libretro.dylib",
-							"linux": "genesis_plus_gx_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "gw",
-					"fullname": "GW",
-					"file": [
-						{
-							"windows": "gw_libretro.dll",
-							"macos": "gw_libretro.dylib",
-							"linux": "gw_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "handy",
-					"fullname": "Handy",
-					"file": [
-						{
-							"windows": "handy_libretro.dll",
-							"macos": "handy_libretro.dylib",
-							"linux": "handy_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "hatari",
-					"fullname": "Hatari",
-					"file": [
-						{
-							"windows": "hatari_libretro.dll",
-							"macos": "hatari_libretro.dylib",
-							"linux": "hatari_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "kronos",
-					"fullname": "Kronos",
-					"file": [
-						{
-							"windows": "kronos_libretro.dll",
-							"macos": "kronos_libretro.dylib",
-							"linux": "kronos_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "lutro",
-					"fullname": "Lutro",
-					"file": [
-						{
-							"windows": "lutro_libretro.dll",
-							"macos": "lutro_libretro.dylib",
-							"linux": "lutro_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "mame",
-					"fullname": "MAME",
-					"file": [
-						{
-							"windows": "mame_libretro.dll",
-							"macos": "mame_libretro.dylib",
-							"linux": "mame_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "mame2003-plus",
-					"fullname": "MAME (2013 - Plus)",
-					"file": [
-						{
-							"windows": "mame2003_plus_libretro.dll",
-							"macos": "mame2003_plus_libretro.dylib",
-							"linux": "mame2003_plus_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "mame2010",
-					"fullname": "MAME (2010)",
-					"file": [
-						{
-							"windows": "mame2010_libretro.dll",
-							"macos": "mame2010_libretro.dylib",
-							"linux": "mame2010_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "melonds",
-					"fullname": "melonDS",
-					"file": [
-						{
-							"windows": "melonds_libretro.dll",
-							"macos": "melonds_libretro.dylib",
-							"linux": "melonds_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "mesen",
-					"fullname": "Mesen",
-					"file": [
-						{
-							"windows": "mesen_libretro.dll",
-							"macos": "mesen_libretro.dylib",
-							"linux": "mesen_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "mesen-s",
-					"fullname": "Mesen-S",
-					"file": [
-						{
-							"windows": "mesen-s_libretro.dll",
-							"macos": "mesen-s_libretro.dylib",
-							"linux": "mesen-s_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "mgba",
-					"fullname": "mGBA",
-					"file": [
-						{
-							"windows": "mgba_libretro.dll",
-							"macos": "mgba_libretro.dylib",
-							"linux": "mgba_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "minivmac",
-					"fullname": "Mini vMac",
-					"file": [
-						{
-							"windows": "minivmac_libretro.dll",
-							"macos": "minivmac_libretro.dylib",
-							"linux": "minivmac_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "mu",
-					"fullname": "Mu",
-					"file": [
-						{
-							"windows": "mu_libretro.dll",
-							"macos": "mu_libretro.dylib",
-							"linux": "mu_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "mupen64plus-next",
-					"fullname": "Mupen64Plus-Next",
-					"file": [
-						{
-							"windows": "mupen64plus_next_libretro.dll",
-							"macos": "mupen64plus_next_libretro.dylib",
-							"linux": "mupen64plus_next_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "nekop2kai",
-					"fullname": "Neko Project II kai",
-					"file": [
-						{
-							"windows": "np2kai_libretro.dll",
-							"macos": "np2kai_libretro.dylib",
-							"linux": "np2kai_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "neocd",
-					"fullname": "NeoCD",
-					"file": [
-						{
-							"windows": "neocd_libretro.dll",
-							"macos": "neocd_libretro.dylib",
-							"linux": "neocd_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "nestopia",
-					"fullname": "Nestopia UE",
-					"file": [
-						{
-							"windows": "nestopia_libretro.dll",
-							"macos": "nestopia_libretro.dylib",
-							"linux": "nestopia_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "nxengine",
-					"fullname": "NX Engine",
-					"file": [
-						{
-							"windows": "nxengine_libretro.dll",
-							"macos": "nxengine_libretro.dylib",
-							"linux": "nxengine_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "o2em",
-					"fullname": "O2EM",
-					"file": [
-						{
-							"windows": "o2em_libretro.dll",
-							"macos": "o2em_libretro.dylib",
-							"linux": "o2em_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "opera",
-					"fullname": "Opera",
-					"file": [
-						{
-							"windows": "opera_libretro.dll",
-							"macos": "opera_libretro.dylib",
-							"linux": "opera_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "parallel-n64",
-					"fullname": "ParaLLEl N64",
-					"file": [
-						{
-							"windows": "parallel_n64_libretro.dll",
-							"macos": "parallel_n64_libretro.dylib",
-							"linux": "parallel_n64_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "pcsx-rearmed",
-					"fullname": "PCSX-ReARMed",
-					"file": [
-						{
-							"windows": "pcsx_rearmed_libretro.dll",
-							"macos": "pcsx_rearmed_libretro.dylib",
-							"linux": "pcsx_rearmed_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "pcsx2",
-					"fullname": "PCSX2",
-					"file": [
-						{
-							"windows": "pcsx2_libretro.dll",
-							"macos": "pcsx2_libretro.dylib",
-							"linux": "pcsx2_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "picodrive",
-					"fullname": "PicoDrive",
-					"file": [
-						{
-							"windows": "picodrive_libretro.dll",
-							"macos": "picodrive_libretro.dylib",
-							"linux": "picodrive_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "play",
-					"fullname": "Play!",
-					"file": [
-						{
-							"windows": "play_libretro.dll",
-							"macos": "play_libretro.dylib",
-							"linux": "play_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "pokemini",
-					"fullname": "PokeMini",
-					"file": [
-						{
-							"windows": "pokemini_libretro.dll",
-							"macos": "pokemini_libretro.dylib",
-							"linux": "pokemini_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "ppsspp",
-					"fullname": "PPSSPP",
-					"file": [
-						{
-							"windows": "ppsspp_libretro.dll",
-							"macos": "ppsspp_libretro.dylib",
-							"linux": "ppsspp_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "prboom",
-					"fullname": "prBoom",
-					"file": [
-						{
-							"windows": "prboom_libretro.dll",
-							"macos": "prboom_libretro.dylib",
-							"linux": "prboom_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "prosystem",
-					"fullname": "ProSystem",
-					"file": [
-						{
-							"windows": "prosystem_libretro.dll",
-							"macos": "prosystem_libretro.dylib",
-							"linux": "prosystem_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "puae",
-					"fullname": "PUAE",
-					"file": [
-						{
-							"windows": "puae_libretro.dll",
-							"macos": "puae_libretro.dylib",
-							"linux": "puae_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "puae2021",
-					"fullname": "PUAE (2021)",
-					"file": [
-						{
-							"windows": "puae2021_libretro.dll",
-							"macos": "puae2021_libretro.dylib",
-							"linux": "puae2021_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "px68k",
-					"fullname": "pc68k",
-					"file": [
-						{
-							"windows": "px68k_libretro.dll",
-							"macos": "px68k_libretro.dylib",
-							"linux": "px68k_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "quasi88",
-					"fullname": "QUASI88",
-					"file": [
-						{
-							"windows": "quasi88_libretro.dll",
-							"macos": "quasi88_libretro.dylib",
-							"linux": "quasi88_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "quicknes",
-					"fullname": "QuickNES",
-					"file": [
-						{
-							"windows": "quicknes_libretro.dll",
-							"macos": "quicknes_libretro.dylib",
-							"linux": "quicknes_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "race",
-					"fullname": "RACE!",
-					"file": [
-						{
-							"windows": "race_libretro.dll",
-							"macos": "race_libretro.dylib",
-							"linux": "race_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "sameboy",
-					"fullname": "SameBoy",
-					"file": [
-						{
-							"windows": "sameboy_libretro.dll",
-							"macos": "sameboy_libretro.dylib",
-							"linux": "sameboy_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "samecdi",
-					"fullname": "SAME_CDI",
-					"file": [
-						{
-							"windows": "same_cdi_libretro.dll",
-							"macos": "same_cdi_libretro.dylib",
-							"linux": "same_cdi_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "scummvm",
-					"fullname": "ScummVM",
-					"file": [
-						{
-							"windows": "scummvm_libretro.dll",
-							"macos": "scummvm_libretro.dylib",
-							"linux": "scummvm_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "simcoupe",
-					"fullname": "SimCoupé",
-					"file": [
-						{
-							"windows": "simcp_libretro.dll",
-							"macos": "simcp_libretro.dylib",
-							"linux": "simcp_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "snes9x",
-					"fullname": "Snes9x - Current",
-					"file": [
-						{
-							"windows": "snes9x_libretro.dll",
-							"macos": "snes9x_libretro.dylib",
-							"linux": "snes9x_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "snes9x2010",
-					"fullname": "Snes9x 2010",
-					"file": [
-						{
-							"windows": "snes9x2010_libretro.dll",
-							"macos": "snes9x2010_libretro.dylib",
-							"linux": "snes9x2010_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "stella",
-					"fullname": "Stella",
-					"file": [
-						{
-							"windows": "stella_libretro.dll",
-							"macos": "stella_libretro.dylib",
-							"linux": "stella_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "theodore",
-					"fullname": "Theodore",
-					"file": [
-						{
-							"windows": "theodore_libretro.dll",
-							"macos": "theodore_libretro.dylib",
-							"linux": "theodore_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "tic80",
-					"fullname": "TIC-80",
-					"file": [
-						{
-							"windows": "tic80_libretro.dll",
-							"macos": "tic80_libretro.dylib",
-							"linux": "tic80_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "uzem",
-					"fullname": "Uzem",
-					"file": [
-						{
-							"windows": "uzem_libretro.dll",
-							"macos": "uzem_libretro.dylib",
-							"linux": "uzem_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "vba-m",
-					"fullname": "VBA-M",
-					"file": [
-						{
-							"windows": "vbam_libretro.dll",
-							"macos": "vbam_libretro.dylib",
-							"linux": "vbam_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "vecx",
-					"fullname": "vecx",
-					"file": [
-						{
-							"windows": "vecx_libretro.dll",
-							"macos": "vecx_libretro.dylib",
-							"linux": "vecx_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "vice128",
-					"fullname": "VICE (x128)",
-					"file": [
-						{
-							"windows": "vice_x128_libretro.dll",
-							"macos": "vice_x128_libretro.dylib",
-							"linux": "vice_x128_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "vice64accurate",
-					"fullname": "VICE (x64sc - Accurate)",
-					"file": [
-						{
-							"windows": "vice_x64sc_libretro.dll",
-							"macos": "vice_x64sc_libretro.dylib",
-							"linux": "vice_x64sc_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "vice64fast",
-					"fullname": "VICE (x64 - Fast)",
-					"file": [
-						{
-							"windows": "vice_x64_libretro.dll",
-							"macos": "vice_x64_libretro.dylib",
-							"linux": "vice_x64_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "vice64supercpu",
-					"fullname": "VICE (x64 - SuperCPU)",
-					"file": [
-						{
-							"windows": "vice_xscpu64_libretro.dll",
-							"macos": "vice_xscpu64_libretro.dylib",
-							"linux": "vice_xscpu64_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "x1",
-					"fullname": "X1",
-					"file": [
-						{
-							"windows": "x1_libretro.dll",
-							"macos": "x1_libretro.dylib",
-							"linux": "x1_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "yabasanshiro",
-					"fullname": "YabaSanshiro",
-					"file": [
-						{
-							"windows": "yabasanshiro_libretro.dll",
-							"macos": "yabasanshiro_libretro.dylib",
-							"linux": "yabasanshiro_libretro.so"
-						}
-					]
-				},
-				{
-					"name": "yabause",
-					"fullname": "Yabause",
-					"file": [
-						{
-							"windows": "yabause_libretro.dll",
-							"macos": "yabause_libretro.dylib",
-							"linux": "yabause_libretro.so"
-						}
-					]
-				}
-			],
-			"command": "{binpath} -L \"{corepath}/{corefile}\" \"{rompath}\""
-		},
-		{
-			"name": "mupen64plus",
-			"fullname": "Mupen64Plus",
-			"platforms": [
-				"n64"
-			],
-			"binpath": [
-				{
-					"windows": [
-						"mupen64plus/mupen64plus-ui-console.exe",
-						"Emulators/mupen64plus/mupen64plus-ui-console.exe",
-						"../mupen64plus/mupen64plus-ui-console.exe"
-					]
-				},
-				{
-					"macos": [
-						"/Applications/mupen64plus.app/Contents/MacOS/mupen64plus",
-						"/usr/local/bin/mupen64plus"
-					]
-				},
-				{
-					"linux": [
-						"/bin/m64p",
-						"/bin/mupen64plus",
-						"/usr/bin/m64p",
-						"/usr/bin/mupen64plus",
-						"/var/lib/flatpak/exports/bin/io.github.m64p.m64p",
-						"~/.local/share/flatpak/exports/bin/io.github.m64p.m64p"
-					]
-				}
-			],
-			"command": "{binpath} --nogui \"{rompath}\""
-		},
-		{
-			"name": "snes9x",
-			"fullname": "Snes9X",
-			"platforms": [
-				"snes"
-			],
-			"binpath": [
-				{
-					"windows": [
-						"snes9x/snes9x-x64.exe",
-						"Emulators/snes9x/snes9x-x64.exe",
-						"../snes9x/snes9x-x64.exe"
-					]
-				},
-				{
-					"macos": [
-						"/Applications/Snes9x.app/Contents/MacOS/Snes9x"
-					]
-				},
-				{
-					"linux": [
-						"/bin/snes9x",
-						"/usr/bin/snes9x",
-						"/var/lib/flatpak/exports/bin/com.snes9x.Snes9x"
-					]
-				}
-			],
-			"command": "{binpath} \"{rompath}\""
-		},
-		{
-			"name": "dolphin",
-			"fullname": "Dolphin",
-			"platforms": [
-				"gc",
-				"wii"
-			],
-			"binpath": [
-				{
-					"windows": [
-						"Dolphin-x64/Dolphin.exe",
-						"Emulators/Dolphin-x64/Dolphin.exe",
-						"../Dolphin-x64/Dolphin.exe"
-					]
-				},
-				{
-					"macos": [
-						"/Applications/Dolphin.app/Contents/MacOS/Dolphin"
-					]
-				},
-				{
-					"linux": [
-							"/bin/dolphin-emu",
-							"/usr/bin/dolphin-emu",
-							"/var/lib/flatpak/exports/bin/org.DolphinEmu.dolphin-emu",
-							"~/.local/share/flatpak/exports/bin/org.DolphinEmu.dolphin-emu",
-							"~/Applications/Dolphin_Emulator*.AppImage",
-							"~/.local/bin/Dolphin_Emulator*.AppImage",
-							"~/bin/Dolphin_Emulator*.AppImage"
-					]
-				}
-			],
-			"command": "{binpath} -b -e \"{rompath}\""
-		}
-	]
-}
+[
+	{
+		"name": "retroarch",
+		"fullname": "RetroArch",
+		"binpath": [
+			{
+				"windows": [
+					"C:/RetroArch-Win64/retroarch.exe",
+					"C:/RetroArch/retroarch.exe",
+					"~/AppData/Roaming/RetroArch/retroarch.exe",
+					"C:/Program Files/RetroArch-Win64/retroarch.exe",
+					"C:/Program Files/RetroArch/retroarch.exe",
+					"C:/Program Files (x86)/RetroArch-Win64/retroarch.exe",
+					"C:/Program Files (x86)/RetroArch/retroarch.exe",
+					"C:/Program Files (x86)/Steam/steamapps/common/RetroArch/retroarch.exe",
+					"D:/Program Files (x86)/Steam/steamapps/common/RetroArch/retroarch.exe",
+					"C:/Program Files/Steam/steamapps/common/RetroArch/retroarch.exe",
+					"D:/Program Files/Steam/steamapps/common/RetroArch/retroarch.exe"
+				]
+			},
+			{
+				"macos": [
+					"/Applications/RetroArch.app/Contents/MacOS/RetroArch"
+				]
+			},
+			{
+				"linux": [
+					"/bin/retroarch",
+					"/usr/bin/retroarch",
+					"/var/lib/flatpak/exports/bin/org.libretro.RetroArch",
+					"~/.local/share/flatpak/exports/bin/org.libretro.RetroArch",
+					"~/Applications/RetroArch-Linux-x86_64.AppImage",
+					"~/.local/bin/RetroArch-Linux-x86_64.AppImage",
+					"~/bin/RetroArch-Linux-x86_64.AppImage"
+				]
+			}
+		],
+		"corepath": [
+			{
+				"windows": [
+					"{binpath}/../cores"
+				]
+			},
+			{
+				"macos": [
+					"~/Library/Application Support/RetroArch/cores",
+					"/Applications/RetroArch.app/Contents/Resources/cores"
+				]
+			},
+			{
+				"linux": [
+					"~/snap/retroarch/current/.config/retroarch/cores",
+					"~/.var/app/org.libretro.RetroArch/config/retroarch/cores",
+					"~/.config/retroarch/cores",
+					"/usr/lib/x86_64-linux-gnu/libretro",
+					"/usr/lib64/libretro",
+					"/usr/lib/libretro",
+					"/usr/local/lib/libretro",
+					"/usr/pkg/lib/libretro"
+				]
+			}
+		],
+		"cores": [
+			{
+				"name": "atari800",
+				"fullname": "Atari800",
+				"file": [
+					{
+						"windows": "atari800_libretro.dll",
+						"macos": "atari800_libretro.dylib",
+						"linux": "atari800_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "beetle-lynx",
+				"fullname": "Mednafen - Lynx",
+				"file": [
+					{
+						"windows": "mednafen_lynx_libretro.dll",
+						"macos": "mednafen_lynx_libretro.dylib",
+						"linux": "mednafen_lynx_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "beetle-ngp",
+				"fullname": "Mednafen - Neo Geo Pocket",
+				"file": [
+					{
+						"windows": "mednafen_ngp_libretro.dll",
+						"macos": "mednafen_ngp_libretro.dylib",
+						"linux": "mednafen_ngp_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "beetle-pc-fx",
+				"fullname": "Mednafen - PC-FX",
+				"file": [
+					{
+						"windows": "mednafen_pcfx_libretro.dll",
+						"macos": "mednafen_pcfx_libretro.dylib",
+						"linux": "mednafen_pcfx_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "beetle-pce-fast",
+				"fullname": "Mednafen - PC Engine (Fast)",
+				"file": [
+					{
+						"windows": "mednafen_pce_fast_libretro.dll",
+						"macos": "mednafen_pce_fast_libretro.dylib",
+						"linux": "mednafen_pce_fast_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "beetle-psx",
+				"fullname": "Mednafen - PlayStation",
+				"file": [
+					{
+						"windows": "mednafen_psx_libretro.dll",
+						"macos": "mednafen_psx_libretro.dylib",
+						"linux": "mednafen_psx_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "beetle-psx-hw",
+				"fullname": "Mednafen - PlayStation (HW)",
+				"file": [
+					{
+						"windows": "mednafen_psx_hw_libretro.dll",
+						"macos": "mednafen_psx_hw_libretro.dylib",
+						"linux": "mednafen_psx_hw_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "beetle-saturn",
+				"fullname": "Mednafen - Saturn",
+				"file": [
+					{
+						"windows": "mednafen_saturn_libretro.dll",
+						"macos": "mednafen_saturn_libretro.dylib",
+						"linux": "mednafen_saturn_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "beetle-saturn-hw",
+				"fullname": "Mednafen - Saturn (HW)",
+				"file": [
+					{
+						"windows": "mednafen_saturn_hw_libretro.dll",
+						"macos": "mednafen_saturn_hw_libretro.dylib",
+						"linux": "mednafen_saturn_hw_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "beetle-supafaust",
+				"fullname": "Mednafen - SNES (SupaFaust)",
+				"file": [
+					{
+						"windows": "mednafen_supafaust_libretro.dll",
+						"macos": "mednafen_supafaust_libretro.dylib",
+						"linux": "mednafen_supafaust_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "beetle-supergrafx",
+				"fullname": "Mednafen - SuperGrafx",
+				"file": [
+					{
+						"windows": "mednafen_supergrafx_libretro.dll",
+						"macos": "mednafen_supergrafx_libretro.dylib",
+						"linux": "mednafen_supergrafx_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "beetle-vb",
+				"fullname": "Mednafen - Virtual Boy",
+				"file": [
+					{
+						"windows": "mednafen_vb_libretro.dll",
+						"macos": "mednafen_vb_libretro.dylib",
+						"linux": "mednafen_vb_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "beetle-wswan",
+				"fullname": "Mednafen - WonderSwan",
+				"file": [
+					{
+						"windows": "mednafen_wswan_libretro.dll",
+						"macos": "mednafen_wswan_libretro.dylib",
+						"linux": "mednafen_wswan_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "blastem",
+				"fullname": "BlastEm",
+				"file": [
+					{
+						"windows": "blastem_libretro.dll",
+						"macos": "blastem_libretro.dylib",
+						"linux": "blastem_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "bluemsx",
+				"fullname": "blueMSX",
+				"file": [
+					{
+						"windows": "bluemsx_libretro.dll",
+						"macos": "bluemsx_libretro.dylib",
+						"linux": "bluemsx_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "bsnes",
+				"fullname": "bsnes",
+				"file": [
+					{
+						"windows": "bsnes_libretro.dll",
+						"macos": "bsnes_libretro.dylib",
+						"linux": "bsnes_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "bshes-hd",
+				"fullname": "bsnes-hd",
+				"file": [
+					{
+						"windows": "bsnes_hd_beta_libretro.dll",
+						"macos": "bsnes_hd_beta_libretro.dylib",
+						"linux": "bsnes_hd_beta_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "bsnes-mercury-accuracy",
+				"fullname": "bsnes-mercury Accuracy",
+				"file": [
+					{
+						"windows": "bsnes_mercury_accuracy_libretro.dll",
+						"macos": "bsnes_mercury_accuracy_libretro.dylib",
+						"linux": "bsnes_mercury_accuracy_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "caprice32",
+				"fullname": "CaPriCe32",
+				"file": [
+					{
+						"windows": "cap32_libretro.dll",
+						"macos": "cap32_libretro.dylib",
+						"linux": "cap32_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "chailove",
+				"fullname": "ChaiLove",
+				"file": [
+					{
+						"windows": "chailove_libretro.dll",
+						"macos": "chailove_libretro.dylib",
+						"linux": "chailove_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "citra",
+				"fullname": "Citra",
+				"file": [
+					{
+						"windows": "citra_libretro.dll",
+						"macos": "citra_libretro.dylib",
+						"linux": "citra_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "crocods",
+				"fullname": "CrocoDS",
+				"file": [
+					{
+						"windows": "crocods_libretro.dll",
+						"macos": "crocods_libretro.dylib",
+						"linux": "crocods_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "desmume",
+				"fullname": "DeSmuME",
+				"file": [
+					{
+						"windows": "desmume_libretro.dll",
+						"macos": "desmume_libretro.dylib",
+						"linux": "desmume_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "dolphin",
+				"fullname": "Dolphin",
+				"file": [
+					{
+						"windows": "dolphin_libretro.dll",
+						"macos": "dolphin_libretro.dylib",
+						"linux": "dolphin_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "dosbox",
+				"fullname": "DOSBox",
+				"file": [
+					{
+						"windows": "dosbox_libretro.dll",
+						"macos": "dosbox_libretro.dylib",
+						"linux": "dosbox_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "dosboxpure",
+				"fullname": "DOSBox (Pure)",
+				"file": [
+					{
+						"windows": "dosbox_pure_libretro.dll",
+						"macos": "dosbox_pure_libretro.dylib",
+						"linux": "dosbox_pure_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "duckstation",
+				"fullname": "DuckStation",
+				"file": [
+					{
+						"windows": "duckstation_libretro.dll",
+						"macos": "duckstation_libretro.dylib",
+						"linux": "duckstation_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "eightyone",
+				"fullname": "EightyOne",
+				"file": [
+					{
+						"windows": "81_libretro.dll",
+						"macos": "81_libretro.dylib",
+						"linux": "81_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "fba2012",
+				"fullname": "FinalBurn Alpha (2012)",
+				"file": [
+					{
+						"windows": "fbalpha2012_libretro.dll",
+						"macos": "fbalpha2012_libretro.dylib",
+						"linux": "fbalpha2012_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "fbneo",
+				"fullname": "FinalBurn Neo",
+				"file": [
+					{
+						"windows": "fbneo_libretro.dll",
+						"macos": "fbneo_libretro.dylib",
+						"linux": "fbneo_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "fceumm",
+				"fullname": "FCEUmm",
+				"file": [
+					{
+						"windows": "fceumm_libretro.dll",
+						"macos": "fceumm_libretro.dylib",
+						"linux": "fceumm_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "flycast",
+				"fullname": "Flycast",
+				"file": [
+					{
+						"windows": "flycast_libretro.dll",
+						"macos": "flycast_libretro.dylib",
+						"linux": "flycast_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "fmsx",
+				"fullname": "fMSX",
+				"file": [
+					{
+						"windows": "fmsx_libretro.dll",
+						"macos": "fmsx_libretro.dylib",
+						"linux": "fmsx_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "freechaf",
+				"fullname": "FreeChaF",
+				"file": [
+					{
+						"windows": "freechaf_libretro.dll",
+						"macos": "freechaf_libretro.dylib",
+						"linux": "freechaf_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "freeintv",
+				"fullname": "FreeIntV",
+				"file": [
+					{
+						"windows": "freeintv_libretro.dll",
+						"macos": "freeintv_libretro.dylib",
+						"linux": "freeintv_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "frodo",
+				"fullname": "Frodo",
+				"file": [
+					{
+						"windows": "frodo_libretro.dll",
+						"macos": "frodo_libretro.dylib",
+						"linux": "frodo_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "fuse",
+				"fullname": "FUSE",
+				"file": [
+					{
+						"windows": "fuse_libretro.dll",
+						"macos": "fuse_libretro.dylib",
+						"linux": "fuse_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "gambatte",
+				"fullname": "Gambatte",
+				"file": [
+					{
+						"windows": "gambatte_libretro.dll",
+						"macos": "gambatte_libretro.dylib",
+						"linux": "gambatte_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "gearboy",
+				"fullname": "Gearboy",
+				"file": [
+					{
+						"windows": "gearboy_libretro.dll",
+						"macos": "gearboy_libretro.dylib",
+						"linux": "gearboy_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "gearcoleco",
+				"fullname": "GearColeco",
+				"file": [
+					{
+						"windows": "gearcoleco_libretro.dll",
+						"macos": "gearcoleco_libretro.dylib",
+						"linux": "gearcoleco_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "genesis-plus-gx",
+				"fullname": "Genesis Plus GX",
+				"file": [
+					{
+						"windows": "genesis_plus_gx_libretro.dll",
+						"macos": "genesis_plus_gx_libretro.dylib",
+						"linux": "genesis_plus_gx_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "gw",
+				"fullname": "GW",
+				"file": [
+					{
+						"windows": "gw_libretro.dll",
+						"macos": "gw_libretro.dylib",
+						"linux": "gw_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "handy",
+				"fullname": "Handy",
+				"file": [
+					{
+						"windows": "handy_libretro.dll",
+						"macos": "handy_libretro.dylib",
+						"linux": "handy_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "hatari",
+				"fullname": "Hatari",
+				"file": [
+					{
+						"windows": "hatari_libretro.dll",
+						"macos": "hatari_libretro.dylib",
+						"linux": "hatari_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "kronos",
+				"fullname": "Kronos",
+				"file": [
+					{
+						"windows": "kronos_libretro.dll",
+						"macos": "kronos_libretro.dylib",
+						"linux": "kronos_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "lutro",
+				"fullname": "Lutro",
+				"file": [
+					{
+						"windows": "lutro_libretro.dll",
+						"macos": "lutro_libretro.dylib",
+						"linux": "lutro_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "mame",
+				"fullname": "MAME",
+				"file": [
+					{
+						"windows": "mame_libretro.dll",
+						"macos": "mame_libretro.dylib",
+						"linux": "mame_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "mame2003-plus",
+				"fullname": "MAME (2013 - Plus)",
+				"file": [
+					{
+						"windows": "mame2003_plus_libretro.dll",
+						"macos": "mame2003_plus_libretro.dylib",
+						"linux": "mame2003_plus_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "mame2010",
+				"fullname": "MAME (2010)",
+				"file": [
+					{
+						"windows": "mame2010_libretro.dll",
+						"macos": "mame2010_libretro.dylib",
+						"linux": "mame2010_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "melonds",
+				"fullname": "melonDS",
+				"file": [
+					{
+						"windows": "melonds_libretro.dll",
+						"macos": "melonds_libretro.dylib",
+						"linux": "melonds_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "mesen",
+				"fullname": "Mesen",
+				"file": [
+					{
+						"windows": "mesen_libretro.dll",
+						"macos": "mesen_libretro.dylib",
+						"linux": "mesen_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "mesen-s",
+				"fullname": "Mesen-S",
+				"file": [
+					{
+						"windows": "mesen-s_libretro.dll",
+						"macos": "mesen-s_libretro.dylib",
+						"linux": "mesen-s_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "mgba",
+				"fullname": "mGBA",
+				"file": [
+					{
+						"windows": "mgba_libretro.dll",
+						"macos": "mgba_libretro.dylib",
+						"linux": "mgba_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "minivmac",
+				"fullname": "Mini vMac",
+				"file": [
+					{
+						"windows": "minivmac_libretro.dll",
+						"macos": "minivmac_libretro.dylib",
+						"linux": "minivmac_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "mu",
+				"fullname": "Mu",
+				"file": [
+					{
+						"windows": "mu_libretro.dll",
+						"macos": "mu_libretro.dylib",
+						"linux": "mu_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "mupen64plus-next",
+				"fullname": "Mupen64Plus-Next",
+				"file": [
+					{
+						"windows": "mupen64plus_next_libretro.dll",
+						"macos": "mupen64plus_next_libretro.dylib",
+						"linux": "mupen64plus_next_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "nekop2kai",
+				"fullname": "Neko Project II kai",
+				"file": [
+					{
+						"windows": "np2kai_libretro.dll",
+						"macos": "np2kai_libretro.dylib",
+						"linux": "np2kai_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "neocd",
+				"fullname": "NeoCD",
+				"file": [
+					{
+						"windows": "neocd_libretro.dll",
+						"macos": "neocd_libretro.dylib",
+						"linux": "neocd_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "nestopia",
+				"fullname": "Nestopia UE",
+				"file": [
+					{
+						"windows": "nestopia_libretro.dll",
+						"macos": "nestopia_libretro.dylib",
+						"linux": "nestopia_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "nxengine",
+				"fullname": "NX Engine",
+				"file": [
+					{
+						"windows": "nxengine_libretro.dll",
+						"macos": "nxengine_libretro.dylib",
+						"linux": "nxengine_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "o2em",
+				"fullname": "O2EM",
+				"file": [
+					{
+						"windows": "o2em_libretro.dll",
+						"macos": "o2em_libretro.dylib",
+						"linux": "o2em_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "opera",
+				"fullname": "Opera",
+				"file": [
+					{
+						"windows": "opera_libretro.dll",
+						"macos": "opera_libretro.dylib",
+						"linux": "opera_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "parallel-n64",
+				"fullname": "ParaLLEl N64",
+				"file": [
+					{
+						"windows": "parallel_n64_libretro.dll",
+						"macos": "parallel_n64_libretro.dylib",
+						"linux": "parallel_n64_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "pcsx-rearmed",
+				"fullname": "PCSX-ReARMed",
+				"file": [
+					{
+						"windows": "pcsx_rearmed_libretro.dll",
+						"macos": "pcsx_rearmed_libretro.dylib",
+						"linux": "pcsx_rearmed_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "pcsx2",
+				"fullname": "PCSX2",
+				"file": [
+					{
+						"windows": "pcsx2_libretro.dll",
+						"macos": "pcsx2_libretro.dylib",
+						"linux": "pcsx2_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "picodrive",
+				"fullname": "PicoDrive",
+				"file": [
+					{
+						"windows": "picodrive_libretro.dll",
+						"macos": "picodrive_libretro.dylib",
+						"linux": "picodrive_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "play",
+				"fullname": "Play!",
+				"file": [
+					{
+						"windows": "play_libretro.dll",
+						"macos": "play_libretro.dylib",
+						"linux": "play_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "pokemini",
+				"fullname": "PokeMini",
+				"file": [
+					{
+						"windows": "pokemini_libretro.dll",
+						"macos": "pokemini_libretro.dylib",
+						"linux": "pokemini_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "ppsspp",
+				"fullname": "PPSSPP",
+				"file": [
+					{
+						"windows": "ppsspp_libretro.dll",
+						"macos": "ppsspp_libretro.dylib",
+						"linux": "ppsspp_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "prboom",
+				"fullname": "prBoom",
+				"file": [
+					{
+						"windows": "prboom_libretro.dll",
+						"macos": "prboom_libretro.dylib",
+						"linux": "prboom_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "prosystem",
+				"fullname": "ProSystem",
+				"file": [
+					{
+						"windows": "prosystem_libretro.dll",
+						"macos": "prosystem_libretro.dylib",
+						"linux": "prosystem_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "puae",
+				"fullname": "PUAE",
+				"file": [
+					{
+						"windows": "puae_libretro.dll",
+						"macos": "puae_libretro.dylib",
+						"linux": "puae_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "puae2021",
+				"fullname": "PUAE (2021)",
+				"file": [
+					{
+						"windows": "puae2021_libretro.dll",
+						"macos": "puae2021_libretro.dylib",
+						"linux": "puae2021_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "px68k",
+				"fullname": "pc68k",
+				"file": [
+					{
+						"windows": "px68k_libretro.dll",
+						"macos": "px68k_libretro.dylib",
+						"linux": "px68k_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "quasi88",
+				"fullname": "QUASI88",
+				"file": [
+					{
+						"windows": "quasi88_libretro.dll",
+						"macos": "quasi88_libretro.dylib",
+						"linux": "quasi88_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "quicknes",
+				"fullname": "QuickNES",
+				"file": [
+					{
+						"windows": "quicknes_libretro.dll",
+						"macos": "quicknes_libretro.dylib",
+						"linux": "quicknes_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "race",
+				"fullname": "RACE!",
+				"file": [
+					{
+						"windows": "race_libretro.dll",
+						"macos": "race_libretro.dylib",
+						"linux": "race_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "sameboy",
+				"fullname": "SameBoy",
+				"file": [
+					{
+						"windows": "sameboy_libretro.dll",
+						"macos": "sameboy_libretro.dylib",
+						"linux": "sameboy_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "samecdi",
+				"fullname": "SAME_CDI",
+				"file": [
+					{
+						"windows": "same_cdi_libretro.dll",
+						"macos": "same_cdi_libretro.dylib",
+						"linux": "same_cdi_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "scummvm",
+				"fullname": "ScummVM",
+				"file": [
+					{
+						"windows": "scummvm_libretro.dll",
+						"macos": "scummvm_libretro.dylib",
+						"linux": "scummvm_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "simcoupe",
+				"fullname": "SimCoupé",
+				"file": [
+					{
+						"windows": "simcp_libretro.dll",
+						"macos": "simcp_libretro.dylib",
+						"linux": "simcp_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "snes9x",
+				"fullname": "Snes9x - Current",
+				"file": [
+					{
+						"windows": "snes9x_libretro.dll",
+						"macos": "snes9x_libretro.dylib",
+						"linux": "snes9x_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "snes9x2010",
+				"fullname": "Snes9x 2010",
+				"file": [
+					{
+						"windows": "snes9x2010_libretro.dll",
+						"macos": "snes9x2010_libretro.dylib",
+						"linux": "snes9x2010_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "stella",
+				"fullname": "Stella",
+				"file": [
+					{
+						"windows": "stella_libretro.dll",
+						"macos": "stella_libretro.dylib",
+						"linux": "stella_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "theodore",
+				"fullname": "Theodore",
+				"file": [
+					{
+						"windows": "theodore_libretro.dll",
+						"macos": "theodore_libretro.dylib",
+						"linux": "theodore_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "tic80",
+				"fullname": "TIC-80",
+				"file": [
+					{
+						"windows": "tic80_libretro.dll",
+						"macos": "tic80_libretro.dylib",
+						"linux": "tic80_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "uzem",
+				"fullname": "Uzem",
+				"file": [
+					{
+						"windows": "uzem_libretro.dll",
+						"macos": "uzem_libretro.dylib",
+						"linux": "uzem_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "vba-m",
+				"fullname": "VBA-M",
+				"file": [
+					{
+						"windows": "vbam_libretro.dll",
+						"macos": "vbam_libretro.dylib",
+						"linux": "vbam_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "vecx",
+				"fullname": "vecx",
+				"file": [
+					{
+						"windows": "vecx_libretro.dll",
+						"macos": "vecx_libretro.dylib",
+						"linux": "vecx_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "vice128",
+				"fullname": "VICE (x128)",
+				"file": [
+					{
+						"windows": "vice_x128_libretro.dll",
+						"macos": "vice_x128_libretro.dylib",
+						"linux": "vice_x128_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "vice64accurate",
+				"fullname": "VICE (x64sc - Accurate)",
+				"file": [
+					{
+						"windows": "vice_x64sc_libretro.dll",
+						"macos": "vice_x64sc_libretro.dylib",
+						"linux": "vice_x64sc_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "vice64fast",
+				"fullname": "VICE (x64 - Fast)",
+				"file": [
+					{
+						"windows": "vice_x64_libretro.dll",
+						"macos": "vice_x64_libretro.dylib",
+						"linux": "vice_x64_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "vice64supercpu",
+				"fullname": "VICE (x64 - SuperCPU)",
+				"file": [
+					{
+						"windows": "vice_xscpu64_libretro.dll",
+						"macos": "vice_xscpu64_libretro.dylib",
+						"linux": "vice_xscpu64_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "x1",
+				"fullname": "X1",
+				"file": [
+					{
+						"windows": "x1_libretro.dll",
+						"macos": "x1_libretro.dylib",
+						"linux": "x1_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "yabasanshiro",
+				"fullname": "YabaSanshiro",
+				"file": [
+					{
+						"windows": "yabasanshiro_libretro.dll",
+						"macos": "yabasanshiro_libretro.dylib",
+						"linux": "yabasanshiro_libretro.so"
+					}
+				]
+			},
+			{
+				"name": "yabause",
+				"fullname": "Yabause",
+				"file": [
+					{
+						"windows": "yabause_libretro.dll",
+						"macos": "yabause_libretro.dylib",
+						"linux": "yabause_libretro.so"
+					}
+				]
+			}
+		],
+		"command": "{binpath} -L \"{corepath}/{corefile}\" \"{rompath}\""
+	},
+	{
+		"name": "mupen64plus",
+		"fullname": "Mupen64Plus",
+		"platforms": [
+			"n64"
+		],
+		"binpath": [
+			{
+				"windows": [
+					"mupen64plus/mupen64plus-ui-console.exe",
+					"Emulators/mupen64plus/mupen64plus-ui-console.exe",
+					"../mupen64plus/mupen64plus-ui-console.exe"
+				]
+			},
+			{
+				"macos": [
+					"/Applications/mupen64plus.app/Contents/MacOS/mupen64plus",
+					"/usr/local/bin/mupen64plus"
+				]
+			},
+			{
+				"linux": [
+					"/bin/m64p",
+					"/bin/mupen64plus",
+					"/usr/bin/m64p",
+					"/usr/bin/mupen64plus",
+					"/var/lib/flatpak/exports/bin/io.github.m64p.m64p",
+					"~/.local/share/flatpak/exports/bin/io.github.m64p.m64p"
+				]
+			}
+		],
+		"command": "{binpath} --nogui \"{rompath}\""
+	},
+	{
+		"name": "snes9x",
+		"fullname": "Snes9X",
+		"platforms": [
+			"snes"
+		],
+		"binpath": [
+			{
+				"windows": [
+					"snes9x/snes9x-x64.exe",
+					"Emulators/snes9x/snes9x-x64.exe",
+					"../snes9x/snes9x-x64.exe"
+				]
+			},
+			{
+				"macos": [
+					"/Applications/Snes9x.app/Contents/MacOS/Snes9x"
+				]
+			},
+			{
+				"linux": [
+					"/bin/snes9x",
+					"/usr/bin/snes9x",
+					"/var/lib/flatpak/exports/bin/com.snes9x.Snes9x"
+				]
+			}
+		],
+		"command": "{binpath} \"{rompath}\""
+	},
+	{
+		"name": "dolphin",
+		"fullname": "Dolphin",
+		"platforms": [
+			"gc",
+			"wii"
+		],
+		"binpath": [
+			{
+				"windows": [
+					"Dolphin-x64/Dolphin.exe",
+					"Emulators/Dolphin-x64/Dolphin.exe",
+					"../Dolphin-x64/Dolphin.exe"
+				]
+			},
+			{
+				"macos": [
+					"/Applications/Dolphin.app/Contents/MacOS/Dolphin"
+				]
+			},
+			{
+				"linux": [
+						"/bin/dolphin-emu",
+						"/usr/bin/dolphin-emu",
+						"/var/lib/flatpak/exports/bin/org.DolphinEmu.dolphin-emu",
+						"~/.local/share/flatpak/exports/bin/org.DolphinEmu.dolphin-emu",
+						"~/Applications/Dolphin_Emulator*.AppImage",
+						"~/.local/bin/Dolphin_Emulator*.AppImage",
+						"~/bin/Dolphin_Emulator*.AppImage"
+				]
+			}
+		],
+		"command": "{binpath} -b -e \"{rompath}\""
+	}
+]

--- a/base_config/systems.json
+++ b/base_config/systems.json
@@ -1,2034 +1,2032 @@
-{
-	"systems_list": [
-		{
-			"name": "amiga",
-			"fullname": "Commodore Amiga",
-			"category": "computer",
-			"extension": [
-				".adf",
-				".adz",
-				".dms",
-				".fdi",
-				".ipf",
-				".hdf",
-				".hdz",
-				".lha",
-				".slave",
-				".info",
-				".cue",
-				".ccd",
-				".chd",
-				".nrg",
-				".mds",
-				".iso",
-				".uae",
-				".m3u",
-				".zip"
-			],
-			"platform": "amiga",
-			"emulator":[
-				{
-					"retroarch": [
-						"puae",
-						"puae2021"
-					]
-				},
-				"fs-uae"
-			]
-		},
-		{
-			"name": "amiga600",
-			"fullname": "Commodore Amiga 600",
-			"extends": "amiga"
-		},
-		{
-			"name": "amiga1200",
-			"fullname": "Commodore Amiga 1200",
-			"extends": "amiga"
-		},
-		{
-			"name": "amigacd32",
-			"fullname": "Commodore Amiga CD32",
-			"category": "console",
-			"extends": "amiga"
-		},
-		{
-			"name": "amstradcpc",
-			"fullname": "Amstrad CPC",
-			"category": "computer",
-			"extension": [
-				".cdt",
-				".cpr",
-				".cpc",
-				".dsk",
-				".kcr",
-				".m3u",
-				".sna",
-				".tap",
-				".voc",
-				".zip"
-			],
-			"platform": "amstradcpc",
-			"emulator": [
-				{
-					"retroarch": [
-						"caprice32",
-						"crocods"
-					]
-				},
-				"caprice"
-			]
-		},
-		{
-			"name": "apple2",
-			"fullname": "Apple II",
-			"category": "computer",
-			"extension": [
-				".dsk",
-				".nib",
-				".zip"
-			],
-			"platform": "apple2",
-			"emulator": [
-				{
-					"retroarch": [
-						"mame"
-					]
-				},
-				"mame",
-				"linapple",
-				"applewin"
-			]
-		},
-		{
-			"name": "atari800",
-			"fullname": "Atari 800",
-			"category": "computer",
-			"extension": [
-				".xfd",
-				".atr",
-				".atr.gz",
-				".xfd.gz",
-				".atx",
-				".cdm",
-				".cas",
-				".car",
-				".bas",
-				".bin",
-				".dcm",
-				".a52",
-				".xex",
-				".zip"
-			],
-			"platform": "atari800",
-			"emulator": [
-				{
-					"retroarch": [
-						"atari800"
-					]
-				},
-				"atari800",
-				"altirra"
-			]
-		},
-		{
-			"name": "atarist",
-			"fullname": "Atari ST",
-			"category": "computer",
-			"extension": [
-				".st",
-				".msa",
-				".stx",
-				".dim",
-				".ipf",
-				".img",
-				".rom",
-				".raw",
-				".ctr",
-				".m3u",
-				".zip"
-			],
-			"platform": "atarist",
-			"emulator": [
-				{
-					"retroarch": [
-						"hatari"
-					]
-				},
-				"hatari"
-			]
-		},
-		{
-			"name": "bbcmicro",
-			"fullname": "BBC Micro",
-			"category": "computer",
-			"extension": [
-				".ssd",
-				".dsd",
-				".adf",
-				".adl",
-				".img",
-				".fdi",
-				".uef",
-				".csw",
-				".zip"
-			],
-			"platform": "bbcmicro",
-			"emulator": [
-				"beebem",
-				"b-em"
-			]
-		},
-		{
-			"name": "c64",
-			"fullname": "Commodore 64",
-			"category": "computer",
-			"extension": [
-				".bin",
-				".cmd",
-				".crt",
-				".d2m",
-				".d4m",
-				".d64",
-				".d6z",
-				".d71",
-				".d7z",
-				".d80",
-				".d81",
-				".d82",
-				".d8z",
-				".g41",
-				".g4z",
-				".g64",
-				".g6z",
-				".gz",
-				".lnx",
-				".m3u",
-				".nbz",
-				".nib",
-				".p00",
-				".prg",
-				".t64",
-				".tap",
-				".vfl",
-				".vsf",
-				".x64",
-				".x6z",
-				".20",
-				".40",
-				".60",
-				".a0",
-				".b0",
-				".rom",
-				".zip"
-			],
-			"platform": "c64",
-			"emulator": [
-				{
-					"retroarch": [
-						"vice64accurate",
-						"vice64fast",
-						"vice64supercpu",
-						"vice128",
-						"frodo"
-					]
-				},
-				"vice",
-				"denise"
-			]
-		},
-		{
-			"name": "coco",
-			"fullname": "Tandy Color Computer",
-			"category": "computer",
-			"extension": [
-				".cas",
-				".c10",
-				".cue",
-				".k7",
-				".dsk",
-				".vdk",
-				".dmk",
-				".rom",
-				".wav",
-				".bas",
-				".asc",
-				".jvc",
-				".os9",
-				".ccc",
-				".sna",
-				".dgn"
-			],
-			"platform": "coco",
-			"emulator": [
-				"xroar"
-			]
-		},
-		{
-			"name": "dos",
-			"fullname": "DOS (PC)",
-			"category": "computer",
-			"extension": [
-				".exe",
-				".com",
-				".bat",
-				".zip",
-				".dosz",
-				".iso",
-				".cue",
-				".ins",
-				".img",
-				".ima",
-				".vhd",
-				".jrc",
-				".tc",
-				".m3u",
-				".m3u8",
-				".conf"
-			],
-			"platform": "dos",
-			"emulator": [
-				{
-					"retroarch": [
-						"dosbox",
-						"dosboxpure"
-					]
-				},
-				"dosbox",
-				"86box",
-				"pcem"
-			]
-		},
-		{
-			"name": "dragon32",
-			"fullname": "Dragon 32",
-			"extends": "coco"
-		},
-		{
-			"name": "macintosh",
-			"fullname": "Macintosh",
-			"category": "computer",
-			"extension": [
-				".dsk",
-				".img",
-				".hvf",
-				".cmd",
-				".zip"
-			],
-			"platform": "macintosh",
-			"emulator": [
-				{
-					"retroarch": [
-						"minivmac"
-					]
-				},
-				"minivmac",
-				"basilisk2"
-			]
-		},
-		{
-			"name": "moto",
-			"fullname": "Thomson MO/TO Series",
-			"category": "computer",
-			"extension": [
-				".fd",
-				".sap",
-				".k7",
-				".rom",
-				".m7",
-				".m5"
-			],
-			"platform": "moto",
-			"emulator": [
-				{
-					"retroarch": [
-						"theodore"
-					]
-				}
-			]
-		},
-		{
-			"name": "msx",
-			"fullname": "MSX",
-			"category": "computer",
-			"extension": [
-				".rom",
-				".ri",
-				".mx1",
-				".mx2",
-				".col",
-				".dsk",
-				".cas",
-				".sg",
-				".sc",
-				".m3u",
-				".zip"
-			],
-			"platform": "msx",
-			"emulator": [
-				{
-					"retroarch": [
-						"bluemsx",
-						"fmsx"
-					]
-				},
-				"openmsx"
-			]
-		},
-		{
-			"name": "msx2",
-			"fullname": "MSX2",
-			"extends": "msx"
-		},
-		{
-			"name": "msxturbor",
-			"fullname": "MSX Turbo R",
-			"extends": "msx"
-		},
-		{
-			"name": "oric",
-			"fullname": "Tangerine Oric",
-			"category": "computer",
-			"extension": [
-				".dsk",
-				".tap",
-				".ort",
-				".wav"
-			],
-			"platform": "oric",
-			"emulator": [
-				"oricutron"
-			]
-		},
-		{
-			"name": "palm",
-			"fullname": "Palm OS",
-			"category": "computer",
-			"extension": [
-				".prc",
-				".pqa",
-				".img",
-				".zip"
-			],
-			"platform": "palm",
-			"emulator": [
-				{
-					"retroarch": [
-						"mu"
-					]
-				}
-			]
-		},
-		{
-			"name": "pc",
-			"fullname": "IBM PC",
-			"extends": "dos"
-		},
-		{
-			"name": "pc88",
-			"fullname": "NEC PC-8000 / PC-8800 Series",
-			"category": "computer",
-			"extension": [
-				".d88",
-				".u88",
-				".m3u"
-			],
-			"platform": "pc88",
-			"emulator": [
-				{
-					"retroarch": [
-						"quasi88"
-					]
-				},
-				"xm8"
-			]
-		},
-		{
-			"name": "pc98",
-			"fullname": "NEC PC-9800 Series",
-			"category": "computer",
-			"extension": [
-				".d98",
-				".zip",
-				".98d",
-				".fdi",
-				".fdd",
-				".2hd",
-				".tfd",
-				".d88",
-				".88d",
-				".hdm",
-				".xdf",
-				".dup",
-				".cmd",
-				".hdi",
-				".thd",
-				".nhd",
-				".hdd",
-				".hdn"
-			],
-			"platform": "pc98",
-			"emulator": [
-				{
-					"retroarch": [
-						"nekop2kai"
-					]
-				}
-			]
-		},
-		{
-			"name": "samcoupe",
-			"fullname": "Sam Coupé",
-			"category": "computer",
-			"extension": [
-				".dsk",
-				".mgt",
-				".sbt",
-				".sad"
-			],
-			"platform": "samcoupe",
-			"emulator": [
-				{
-					"retroarch": [
-						"simcoupe"
-					]
-				},
-				"simcoupe"
-			]
-		},
-		{
-			"name": "spectravideo",
-			"fullname": "Spectravideo",
-			"extends": "msx"
-		},
-		{
-			"name": "tanodragon",
-			"fullname": "Tano Dragon",
-			"extends": "coco"
-		},
-		{
-			"name": "ti99",
-			"fullname": "Texas Instruments TI-99",
-			"category": "computer",
-			"extension": [
-				".ctg"
-			],
-			"platform": "ti99",
-			"emulator": [
-				"ti99sim"
-			]
-		},
-		{
-			"name": "to8",
-			"fullname": "Thomson TO8",
-			"extends": "moto"
-		},
-		{
-			"name": "trs-80",
-			"fullname": "Tandy TRS-80",
-			"category": "computer",
-			"extension": [
-				".dsk",
-				".cas",
-				".cmd",
-				".hex",
-				".bds",
-				".zip"
-			],
-			"platform": "trs-80",
-			"emulator": [
-				"sdltrs",
-				"trs80gp"
-			]
-		},
-		{
-			"name": "vic20",
-			"fullname": "Commodore VIC-20",
-			"extends": "c64"
-		},
-		{
-			"name": "x1",
-			"fullname": "Sharp X1",
-			"category": "computer",
-			"extension": [
-				".dx1",
-				".2d",
-				".2hd",
-				".tfd",
-				".d88",
-				".88d",
-				".hdm",
-				".xdf",
-				".dup",
-				".cmd",
-				".zip"
-			],
-			"platform": "x1",
-			"emulator": [
-				{
-					"retroarch": [
-						"x1"
-					]
-				}
-			]
-		},
-		{
-			"name": "x68000",
-			"fullname": "Sharp X68000",
-			"category": "computer",
-			"extension": [
-				".dim",
-				".img",
-				".d88",
-				".88d",
-				".hdm",
-				".dup",
-				".2hd",
-				".xdf",
-				".hdf",
-				".cmd",
-				".m3u",
-				".zip"
-			],
-			"platform": "x68000",
-			"emulator": [
-				{
-					"retroarch": [
-						"px68k"
-					]
-				}
-			]
-		},
-		{
-			"name": "zmachine",
-			"fullname": "Infocom Z-machine",
-			"category": "computer",
-			"extension": [
-				".dat",
-				".z1",
-				".z2",
-				".z3",
-				".z4",
-				".z5",
-				".z6",
-				".z7",
-				".z8",
-				".zip"
-			],
-			"platform": "zmachine",
-			"emulator": [
-				"frotz"
-			]
-		},
-		{
-			"name": "zx81",
-			"fullname": "Sinclair ZX81",
-			"category": "computer",
-			"extension": [
-				".p",
-				".tzx",
-				".t81"
-			],
-			"platform": "zx81",
-			"emulator": [
-				{
-					"retroarch": [
-						"eightyone"
-					]
-				},
-				"zesaurux"
-			]
-		},
-		{
-			"name": "zxspectrum",
-			"fullname": "Sinclair ZX Spectrum",
-			"category": "computer",
-			"extension": [
-				".sna",
-				".szx",
-				".z80",
-				".tap",
-				".tzx",
-				".gz",
-				".udi",
-				".mgt",
-				".img",
-				".trd",
-				".scl",
-				".dsk"
-			],
-			"platform": "zxspectrum",
-			"emulator": [
-				{
-					"retroarch": [
-						"fuse"
-					]
-				},
-				"fuse",
-				"zesaurux"
-			]
-		},
-		{
-			"name": "cavestory",
-			"fullname": "Cave Story (NXEngine)",
-			"category": "engine",
-			"extension": [
-				".exe"
-			],
-			"platform": "cavestory",
-			"emulator": [
-				{
-					"retroarch": [
-						"nxengine"
-					]
-				}
-			]
-		},
-		{
-			"name": "chailove",
-			"fullname": "ChaiLove",
-			"category": "engine",
-			"extension": [
-				".chai",
-				".chailove"
-			],
-			"platform": "chailove",
-			"emulator": [
-				{
-					"retroarch": [
-						"chailove"
-					]
-				}
-			]
-		},
-		{
-			"name": "doom",
-			"fullname": "DOOM",
-			"category": "engine",
-			"extension": [
-				".wad",
-				".iwad",
-				".pwad"
-			],
-			"platform": "doom",
-			"emulator": [
-				{
-					"retroarch": [
-						"prboom"
-					]
-				},
-				"zdoom"
-			]
-		},
-		{
-			"name": "godot",
-			"fullname": "Godot",
-			"category": "engine",
-			"extension": [
-				".pck",
-				".zip"
-			],
-			"platform": "godot",
-			"emulator": [
-				{
-					"retroarch": [
-						"godot"
-					]
-				},
-				"godot"
-			]
-		},
-		{
-			"name": "lutro",
-			"fullname": "Lutro",
-			"category": "engine",
-			"extension": [
-				".lutro",
-				".lua"
-			],
-			"platform": "lutro",
-			"emulator": [
-				{
-					"retroarch": [
-						"lutro"
-					]
-				}
-			]
-		},
-		{
-			"name": "openbor",
-			"fullname": "OpenBOR",
-			"category": "engine",
-			"extension": [
-				".pak"
-			],
-			"platform": "openbor",
-			"emulator": [
-				"openbor"
-			]
-		},
-		{
-			"name": "pico8",
-			"fullname": "PICO-8",
-			"category": "engine",
-			"extension": [
-				".p8",
-				".png"
-			],
-			"platform": "pico8",
-			"emulator": [
-				"pico8"
-			]
-		},
-		{
-			"name": "scummvm",
-			"fullname": "ScummVM",
-			"category": "engine",
-			"extension": [
-				".scummvm"
-			],
-			"platform": "scummvm",
-			"emulator": [
-				{
-					"retroarch": [
-						"scummvm"
-					]
-				},
-				"scummvm"
-			]
-		},
-		{
-			"name": "solarus",
-			"fullname": "Solarus",
-			"category": "engine",
-			"extension": [
-				".solarus"
-			],
-			"platform": "solarus",
-			"emulator": [
-				"solarus"
-			]
-		},
-		{
-			"name": "stratagus",
-			"fullname": "Stratagus",
-			"category": "engine",
-			"extension": [
-				".exe",
-				""
-			],
-			"platform": "stratagus",
-			"emulator": [
-				"stratagus"
-			]
-		},
-		{
-			"name": "tic80",
-			"fullname": "TIC-80",
-			"category": "engine",
-			"extension": [
-				".tic"
-			],
-			"platform": "tic80",
-			"emulator": [
-				{
-					"retroarch": [
-						"tic80"
-					]
-				},
-				"tic80"
-			]
-		},
-		{
-			"name": "3do",
-			"fullname": "3DO",
-			"category": "console",
-			"extension": [
-				".iso",
-				".bin",
-				".chd",
-				".cue",
-				".zip"
-			],
-			"platform": "3do",
-			"emulator": [
-				{
-					"retroarch": [
-						"opera"
-					]
-				},
-				"opera"
-			]
-		},
-		{
-			"name": "64dd",
-			"fullname": "Nintendo 64 DD",
-			"extends": "n64"
-		},
-		{
-			"name": "astrocade",
-			"fullname": "Bally Astrocade",
-			"extends": "arcade"
-		},
-		{
-			"name": "atari2600",
-			"fullname": "Atari 2600",
-			"category": "console",
-			"extension": [
-				".a26",
-				".bin",
-				".gz",
-				".rom",
-				".zip"
-			],
-			"platform": "atari2600",
-			"emulator": [
-				{
-					"retroarch": [
-						"stella"
-					]
-				},
-				"stella"
-			]
-		},
-		{
-			"name": "atari5200",
-			"fullname": "Atari 5200",
-			"category": "console",
-			"extends": "atari800"
-		},
-		{
-			"name": "atari7800",
-			"fullname": "Atari 7800",
-			"category": "console",
-			"extension": [
-				".a78",
-				".bin",
-				".zip"
-			],
-			"platform": "atari7800",
-			"emulator": [
-				{
-					"retroarch": [
-						"prosystem"
-					]
-				},
-				"prosystem",
-				"a7800"
-			]
-		},
-		{
-			"name": "atarijaguar",
-			"fullname": "Atari Jaguar",
-			"category": "console",
-			"extension": [
-				".j64",
-				".jag",
-				".rom",
-				".abs",
-				".cof",
-				".bin",
-				".prg"
-			],
-			"platform": "atarijaguar",
-			"emulator": [
-				{
-					"retroarch": [
-						"virtualjaguar"
-					]
-				},
-				"virtualjaguar"
-			]
-		},
-		{
-			"name": "atarijaguarcd",
-			"fullname": "Atari Jaguar CD",
-			"emulator": [
-				"project-tempest"
-			],
-			"extends": "atarijaguar"
-		},
-		{
-			"name": "atarilynx",
-			"fullname": "Atari Lynx",
-			"category": "console",
-			"extension": [
-				".lnx",
-				".o",
-				".zip"
-			],
-			"platform": "atarilynx",
-			"emulator": [
-				{
-					"retroarch": [
-						"handy",
-						"beetle-lynx"
-					]
-				},
-				"mednafen"
-			]
-		},
-		{
-			"name": "atarixe",
-			"fullname": "Atari XE",
-			"category": "console",
-			"extends": "atari800"
-		},
-		{
-			"name": "cdimono1",
-			"fullname": "Philips CD-i",
-			"category": "console",
-			"extension": [
-				".chd",
-				".cue",
-				".iso"
-			],
-			"platform": "cdimono1",
-			"emulator": [
-				{
-					"retroarch": [
-						"samecdi"
-					]
-				}
-			]
-		},
-		{
-			"name": "cdtv",
-			"fullname": "Commodore CDTV",
-			"category": "console",
-			"extends": "amiga"
-		},
-		{
-			"name": "channelf",
-			"fullname": "Fairchild Channel F",
-			"category": "console",
-			"extension": [
-				".bin",
-				".rom",
-				".chf",
-				".zip"
-			],
-			"platform": "channelf",
-			"emulator": [
-				{
-					"retroarch": [
-						"freechaf"
-					]
-				}
-			]
-		},
-		{
-			"name": "colecovision",
-			"fullname": "ColecoVision",
-			"category": "console",
-			"extension": [
-				".col",
-				".cv",
-				".bin",
-				".rom"
-			],
-			"platform": "colecovision",
-			"emulator": [
-				{
-					"retroarch": [
-						"bluemsx",
-						"gearcoleco"
-					]
-				},
-				"colem",
-				"dsp",
-				"ares",
-				"higan"
-			]
-		},
-		{
-			"name": "dreamcast",
-			"fullname": "Sega Dreamcast",
-			"category": "console",
-			"extension": [
-				".cdi",
-				".gdi",
-				".chd",
-				".cue",
-				".bin",
-				".elf",
-				".lst",
-				".dat",
-				".m3u",
-				".zip"
-			],
-			"platform": "dreamcast",
-			"emulator": [
-				{
-					"retroarch": [
-						"flycast"
-					]
-				},
-				"flycast",
-				"redream"
-			]
-		},
-		{
-			"name": "famicom",
-			"fullname": "Nintendo Family Computer",
-			"extends": "nes"
-		},
-		{
-			"name": "fds",
-			"fullname": "Nintendo Famicom Disk System",
-			"extends": "nes"
-		},
-		{
-			"name": "gameandwatch",
-			"fullname": "Nintendo Game & Watch",
-			"category": "console",
-			"extension": [
-				".mgw",
-				".zip"
-			],
-			"platform": "gameandwatch",
-			"emulator": [
-				{
-					"retroarch": [
-						"gw"
-					]
-				}
-			]
-		},
-		{
-			"name": "gamegear",
-			"fullname": "Sega Game Gear",
-			"extends": "mastersystem"
-		},
-		{
-			"name": "gb",
-			"fullname": "Nintendo Game Boy",
-			"category": "console",
-			"extension": [
-				".gb",
-				".gbc",
-				".bin",
-				".rom",
-				".dmg",
-				".cgb",
-				".sgb",
-				".zip"
-			],
-			"platform": "gb",
-			"emulator": [
-				{
-					"retroarch": [
-						"sameboy",
-						"gambatte",
-						"gearboy"
-					]
-				},
-				"sameboy",
-				"gambatte",
-				"gearboy"
-			]
-		},
-		{
-			"name": "gbc",
-			"fullname": "Nintendo Game Boy Color",
-			"extends": "gb"
-		},
-		{
-			"name": "gba",
-			"fullname": "Nintendo Game Boy Advance",
-			"category": "console",
-			"extension": [
-				".gba",
-				".agb",
-				".bin",
-				".zip"
-			],
-			"platform": "gba",
-			"emulator": [
-				{
-					"retroarch": [
-						"mgba",
-						"vba-m"
-					]
-				},
-				"mgba",
-				"vba-m"
-			]
-		},
-		{
-			"name": "gc",
-			"fullname": "Nintendo GameCube",
-			"category": "console",
-			"extension": [
-				".elf",
-				".iso",
-				".gcm",
-				".dol",
-				".tgc",
-				".wbfs",
-				".ciso",
-				".gcz",
-				".wad",
-				".rvz"
-			],
-			"platform": "gc",
-			"emulator": [
-				{
-					"retroarch": [
-						"dolphin"
-					]
-				},
-				"dolphin"
-			]
-		},
-		{
-			"name": "genesis",
-			"fullname": "Sega Genesis",
-			"category": "console",
-			"extension": [
-				".mdx",
-				".md",
-				".smd",
-				".gen",
-				".bin",
-				".cue",
-				".iso",
-				".sms",
-				".gg",
-				".sg",
-				".68k",
-				".chd",
-				".zip"
-			],
-			"platform": "genesis",
-			"emulator": [
-				{
-					"retroarch": [
-						"genesis-plus-gx",
-						"blastem",
-						"picodrive"
-					]
-				},
-				"blastem"
-			]
-		},
-		{
-			"name": "megadrive",
-			"fullname": "Sega Mega Drive",
-			"extends": "genesis"
-		},
-		{
-			"name": "sega32x",
-			"fullname": "Sega 32X",
-			"extends": "genesis"
-		},
-		{
-			"name": "segacd",
-			"fullname": "Sega CD",
-			"extends": "genesis"
-		},
-		{
-			"name": "gx4000",
-			"fullname": "Amstrad GX4000",
-			"extends": "amstradcpc"
-		},
-		{
-			"name": "intellivision",
-			"fullname": "Mattel Electronics Intellivision",
-			"category": "console",
-			"extension": [
-				".int",
-				".rom",
-				".bin",
-				".itv",
-				".zip"
-			],
-			"platform": "intellivision",
-			"emulator": [
-				{
-					"retroarch": [
-						"freeintv"
-					]
-				},
-				"freeintv",
-				"jzintv"
-			]
-		},
-		{
-			"name": "mastersystem",
-			"fullname": "Sega Master System",
-			"category": "console",
-			"extension": [
-				".sms",
-				".bin",
-				".rom",
-				".zip"
-			],
-			"platform": "mastersystem",
-			"emulator": [
-				{
-					"retroarch": [
-						"genesis-plus-gx",
-						"picodrive"
-					]
-				},
-				"emulicious"
-			]
-		},
-		{
-			"name": "multivision",
-			"fullname": "Othello Multivision",
-			"extends": "sg-1000"
-		},
-		{
-			"name": "n64",
-			"fullname": "Nintendo 64",
-			"category": "console",
-			"extension": [
-				".n64",
-				".v64",
-				".z64",
-				".bin",
-				".u1",
-				".ndd",
-				".zip"
-			],
-			"platform": "n64",
-			"emulator": [
-				{
-					"retroarch": [
-						"mupen64plus-next",
-						"parallel-n64"
-					]
-				},
-				"mupen64plus",
-				"project64"
-			]
-		},
-		{
-			"name": "nds",
-			"fullname": "Nintendo DS",
-			"category": "console",
-			"extension": [
-				".nds",
-				".bin"
-			],
-			"platform": "nds",
-			"emulator": [
-				{
-					"retroarch": [
-						"desmume",
-						"melonds"
-					]
-				},
-				"desmume",
-				"melonds"
-			]
-		},
-		{
-			"name": "neogeocd",
-			"fullname": "SNK Neo Geo CD",
-			"category": "console",
-			"emulator": [
-				{
-					"retroarch": [
-						"neocd",
-						"mame",
-						"fbneo"
-					]
-				},
-				"mame",
-				"fbneo"
-			],
-			"extends": "neogeo"
-		},
-		{
-			"name": "neogeocdjp",
-			"extends": "neogeocd"
+[
+	{
+		"name": "amiga",
+		"fullname": "Commodore Amiga",
+		"category": "computer",
+		"extension": [
+			".adf",
+			".adz",
+			".dms",
+			".fdi",
+			".ipf",
+			".hdf",
+			".hdz",
+			".lha",
+			".slave",
+			".info",
+			".cue",
+			".ccd",
+			".chd",
+			".nrg",
+			".mds",
+			".iso",
+			".uae",
+			".m3u",
+			".zip"
+		],
+		"platform": "amiga",
+		"emulator":[
+			{
+				"retroarch": [
+					"puae",
+					"puae2021"
+				]
 			},
-		{
-			"name": "nes",
-			"fullname": "Nintendo Entertainment System",
-			"category": "console",
-			"extension": [
-				".nes",
-				".fds",
-				".unf",
-				".unif",
-				".zip"
-			],
-			"platform": "nes",
-			"emulator": [
-				{
-					"retroarch": [
-						"nestopia",
-						"fceumm",
-						"mesen",
-						"quicknes"
-					]
-				},
-				"mesen",
-				"punes",
-				"nestopia"
-			]
+			"fs-uae"
+		]
+	},
+	{
+		"name": "amiga600",
+		"fullname": "Commodore Amiga 600",
+		"extends": "amiga"
+	},
+	{
+		"name": "amiga1200",
+		"fullname": "Commodore Amiga 1200",
+		"extends": "amiga"
+	},
+	{
+		"name": "amigacd32",
+		"fullname": "Commodore Amiga CD32",
+		"category": "console",
+		"extends": "amiga"
+	},
+	{
+		"name": "amstradcpc",
+		"fullname": "Amstrad CPC",
+		"category": "computer",
+		"extension": [
+			".cdt",
+			".cpr",
+			".cpc",
+			".dsk",
+			".kcr",
+			".m3u",
+			".sna",
+			".tap",
+			".voc",
+			".zip"
+		],
+		"platform": "amstradcpc",
+		"emulator": [
+			{
+				"retroarch": [
+					"caprice32",
+					"crocods"
+				]
+			},
+			"caprice"
+		]
+	},
+	{
+		"name": "apple2",
+		"fullname": "Apple II",
+		"category": "computer",
+		"extension": [
+			".dsk",
+			".nib",
+			".zip"
+		],
+		"platform": "apple2",
+		"emulator": [
+			{
+				"retroarch": [
+					"mame"
+				]
+			},
+			"mame",
+			"linapple",
+			"applewin"
+		]
+	},
+	{
+		"name": "atari800",
+		"fullname": "Atari 800",
+		"category": "computer",
+		"extension": [
+			".xfd",
+			".atr",
+			".atr.gz",
+			".xfd.gz",
+			".atx",
+			".cdm",
+			".cas",
+			".car",
+			".bas",
+			".bin",
+			".dcm",
+			".a52",
+			".xex",
+			".zip"
+		],
+		"platform": "atari800",
+		"emulator": [
+			{
+				"retroarch": [
+					"atari800"
+				]
+			},
+			"atari800",
+			"altirra"
+		]
+	},
+	{
+		"name": "atarist",
+		"fullname": "Atari ST",
+		"category": "computer",
+		"extension": [
+			".st",
+			".msa",
+			".stx",
+			".dim",
+			".ipf",
+			".img",
+			".rom",
+			".raw",
+			".ctr",
+			".m3u",
+			".zip"
+		],
+		"platform": "atarist",
+		"emulator": [
+			{
+				"retroarch": [
+					"hatari"
+				]
+			},
+			"hatari"
+		]
+	},
+	{
+		"name": "bbcmicro",
+		"fullname": "BBC Micro",
+		"category": "computer",
+		"extension": [
+			".ssd",
+			".dsd",
+			".adf",
+			".adl",
+			".img",
+			".fdi",
+			".uef",
+			".csw",
+			".zip"
+		],
+		"platform": "bbcmicro",
+		"emulator": [
+			"beebem",
+			"b-em"
+		]
+	},
+	{
+		"name": "c64",
+		"fullname": "Commodore 64",
+		"category": "computer",
+		"extension": [
+			".bin",
+			".cmd",
+			".crt",
+			".d2m",
+			".d4m",
+			".d64",
+			".d6z",
+			".d71",
+			".d7z",
+			".d80",
+			".d81",
+			".d82",
+			".d8z",
+			".g41",
+			".g4z",
+			".g64",
+			".g6z",
+			".gz",
+			".lnx",
+			".m3u",
+			".nbz",
+			".nib",
+			".p00",
+			".prg",
+			".t64",
+			".tap",
+			".vfl",
+			".vsf",
+			".x64",
+			".x6z",
+			".20",
+			".40",
+			".60",
+			".a0",
+			".b0",
+			".rom",
+			".zip"
+		],
+		"platform": "c64",
+		"emulator": [
+			{
+				"retroarch": [
+					"vice64accurate",
+					"vice64fast",
+					"vice64supercpu",
+					"vice128",
+					"frodo"
+				]
+			},
+			"vice",
+			"denise"
+		]
+	},
+	{
+		"name": "coco",
+		"fullname": "Tandy Color Computer",
+		"category": "computer",
+		"extension": [
+			".cas",
+			".c10",
+			".cue",
+			".k7",
+			".dsk",
+			".vdk",
+			".dmk",
+			".rom",
+			".wav",
+			".bas",
+			".asc",
+			".jvc",
+			".os9",
+			".ccc",
+			".sna",
+			".dgn"
+		],
+		"platform": "coco",
+		"emulator": [
+			"xroar"
+		]
+	},
+	{
+		"name": "dos",
+		"fullname": "DOS (PC)",
+		"category": "computer",
+		"extension": [
+			".exe",
+			".com",
+			".bat",
+			".zip",
+			".dosz",
+			".iso",
+			".cue",
+			".ins",
+			".img",
+			".ima",
+			".vhd",
+			".jrc",
+			".tc",
+			".m3u",
+			".m3u8",
+			".conf"
+		],
+		"platform": "dos",
+		"emulator": [
+			{
+				"retroarch": [
+					"dosbox",
+					"dosboxpure"
+				]
+			},
+			"dosbox",
+			"86box",
+			"pcem"
+		]
+	},
+	{
+		"name": "dragon32",
+		"fullname": "Dragon 32",
+		"extends": "coco"
+	},
+	{
+		"name": "macintosh",
+		"fullname": "Macintosh",
+		"category": "computer",
+		"extension": [
+			".dsk",
+			".img",
+			".hvf",
+			".cmd",
+			".zip"
+		],
+		"platform": "macintosh",
+		"emulator": [
+			{
+				"retroarch": [
+					"minivmac"
+				]
+			},
+			"minivmac",
+			"basilisk2"
+		]
+	},
+	{
+		"name": "moto",
+		"fullname": "Thomson MO/TO Series",
+		"category": "computer",
+		"extension": [
+			".fd",
+			".sap",
+			".k7",
+			".rom",
+			".m7",
+			".m5"
+		],
+		"platform": "moto",
+		"emulator": [
+			{
+				"retroarch": [
+					"theodore"
+				]
+			}
+		]
+	},
+	{
+		"name": "msx",
+		"fullname": "MSX",
+		"category": "computer",
+		"extension": [
+			".rom",
+			".ri",
+			".mx1",
+			".mx2",
+			".col",
+			".dsk",
+			".cas",
+			".sg",
+			".sc",
+			".m3u",
+			".zip"
+		],
+		"platform": "msx",
+		"emulator": [
+			{
+				"retroarch": [
+					"bluemsx",
+					"fmsx"
+				]
+			},
+			"openmsx"
+		]
+	},
+	{
+		"name": "msx2",
+		"fullname": "MSX2",
+		"extends": "msx"
+	},
+	{
+		"name": "msxturbor",
+		"fullname": "MSX Turbo R",
+		"extends": "msx"
+	},
+	{
+		"name": "oric",
+		"fullname": "Tangerine Oric",
+		"category": "computer",
+		"extension": [
+			".dsk",
+			".tap",
+			".ort",
+			".wav"
+		],
+		"platform": "oric",
+		"emulator": [
+			"oricutron"
+		]
+	},
+	{
+		"name": "palm",
+		"fullname": "Palm OS",
+		"category": "computer",
+		"extension": [
+			".prc",
+			".pqa",
+			".img",
+			".zip"
+		],
+		"platform": "palm",
+		"emulator": [
+			{
+				"retroarch": [
+					"mu"
+				]
+			}
+		]
+	},
+	{
+		"name": "pc",
+		"fullname": "IBM PC",
+		"extends": "dos"
+	},
+	{
+		"name": "pc88",
+		"fullname": "NEC PC-8000 / PC-8800 Series",
+		"category": "computer",
+		"extension": [
+			".d88",
+			".u88",
+			".m3u"
+		],
+		"platform": "pc88",
+		"emulator": [
+			{
+				"retroarch": [
+					"quasi88"
+				]
+			},
+			"xm8"
+		]
+	},
+	{
+		"name": "pc98",
+		"fullname": "NEC PC-9800 Series",
+		"category": "computer",
+		"extension": [
+			".d98",
+			".zip",
+			".98d",
+			".fdi",
+			".fdd",
+			".2hd",
+			".tfd",
+			".d88",
+			".88d",
+			".hdm",
+			".xdf",
+			".dup",
+			".cmd",
+			".hdi",
+			".thd",
+			".nhd",
+			".hdd",
+			".hdn"
+		],
+		"platform": "pc98",
+		"emulator": [
+			{
+				"retroarch": [
+					"nekop2kai"
+				]
+			}
+		]
+	},
+	{
+		"name": "samcoupe",
+		"fullname": "Sam Coupé",
+		"category": "computer",
+		"extension": [
+			".dsk",
+			".mgt",
+			".sbt",
+			".sad"
+		],
+		"platform": "samcoupe",
+		"emulator": [
+			{
+				"retroarch": [
+					"simcoupe"
+				]
+			},
+			"simcoupe"
+		]
+	},
+	{
+		"name": "spectravideo",
+		"fullname": "Spectravideo",
+		"extends": "msx"
+	},
+	{
+		"name": "tanodragon",
+		"fullname": "Tano Dragon",
+		"extends": "coco"
+	},
+	{
+		"name": "ti99",
+		"fullname": "Texas Instruments TI-99",
+		"category": "computer",
+		"extension": [
+			".ctg"
+		],
+		"platform": "ti99",
+		"emulator": [
+			"ti99sim"
+		]
+	},
+	{
+		"name": "to8",
+		"fullname": "Thomson TO8",
+		"extends": "moto"
+	},
+	{
+		"name": "trs-80",
+		"fullname": "Tandy TRS-80",
+		"category": "computer",
+		"extension": [
+			".dsk",
+			".cas",
+			".cmd",
+			".hex",
+			".bds",
+			".zip"
+		],
+		"platform": "trs-80",
+		"emulator": [
+			"sdltrs",
+			"trs80gp"
+		]
+	},
+	{
+		"name": "vic20",
+		"fullname": "Commodore VIC-20",
+		"extends": "c64"
+	},
+	{
+		"name": "x1",
+		"fullname": "Sharp X1",
+		"category": "computer",
+		"extension": [
+			".dx1",
+			".2d",
+			".2hd",
+			".tfd",
+			".d88",
+			".88d",
+			".hdm",
+			".xdf",
+			".dup",
+			".cmd",
+			".zip"
+		],
+		"platform": "x1",
+		"emulator": [
+			{
+				"retroarch": [
+					"x1"
+				]
+			}
+		]
+	},
+	{
+		"name": "x68000",
+		"fullname": "Sharp X68000",
+		"category": "computer",
+		"extension": [
+			".dim",
+			".img",
+			".d88",
+			".88d",
+			".hdm",
+			".dup",
+			".2hd",
+			".xdf",
+			".hdf",
+			".cmd",
+			".m3u",
+			".zip"
+		],
+		"platform": "x68000",
+		"emulator": [
+			{
+				"retroarch": [
+					"px68k"
+				]
+			}
+		]
+	},
+	{
+		"name": "zmachine",
+		"fullname": "Infocom Z-machine",
+		"category": "computer",
+		"extension": [
+			".dat",
+			".z1",
+			".z2",
+			".z3",
+			".z4",
+			".z5",
+			".z6",
+			".z7",
+			".z8",
+			".zip"
+		],
+		"platform": "zmachine",
+		"emulator": [
+			"frotz"
+		]
+	},
+	{
+		"name": "zx81",
+		"fullname": "Sinclair ZX81",
+		"category": "computer",
+		"extension": [
+			".p",
+			".tzx",
+			".t81"
+		],
+		"platform": "zx81",
+		"emulator": [
+			{
+				"retroarch": [
+					"eightyone"
+				]
+			},
+			"zesaurux"
+		]
+	},
+	{
+		"name": "zxspectrum",
+		"fullname": "Sinclair ZX Spectrum",
+		"category": "computer",
+		"extension": [
+			".sna",
+			".szx",
+			".z80",
+			".tap",
+			".tzx",
+			".gz",
+			".udi",
+			".mgt",
+			".img",
+			".trd",
+			".scl",
+			".dsk"
+		],
+		"platform": "zxspectrum",
+		"emulator": [
+			{
+				"retroarch": [
+					"fuse"
+				]
+			},
+			"fuse",
+			"zesaurux"
+		]
+	},
+	{
+		"name": "cavestory",
+		"fullname": "Cave Story (NXEngine)",
+		"category": "engine",
+		"extension": [
+			".exe"
+		],
+		"platform": "cavestory",
+		"emulator": [
+			{
+				"retroarch": [
+					"nxengine"
+				]
+			}
+		]
+	},
+	{
+		"name": "chailove",
+		"fullname": "ChaiLove",
+		"category": "engine",
+		"extension": [
+			".chai",
+			".chailove"
+		],
+		"platform": "chailove",
+		"emulator": [
+			{
+				"retroarch": [
+					"chailove"
+				]
+			}
+		]
+	},
+	{
+		"name": "doom",
+		"fullname": "DOOM",
+		"category": "engine",
+		"extension": [
+			".wad",
+			".iwad",
+			".pwad"
+		],
+		"platform": "doom",
+		"emulator": [
+			{
+				"retroarch": [
+					"prboom"
+				]
+			},
+			"zdoom"
+		]
+	},
+	{
+		"name": "godot",
+		"fullname": "Godot",
+		"category": "engine",
+		"extension": [
+			".pck",
+			".zip"
+		],
+		"platform": "godot",
+		"emulator": [
+			{
+				"retroarch": [
+					"godot"
+				]
+			},
+			"godot"
+		]
+	},
+	{
+		"name": "lutro",
+		"fullname": "Lutro",
+		"category": "engine",
+		"extension": [
+			".lutro",
+			".lua"
+		],
+		"platform": "lutro",
+		"emulator": [
+			{
+				"retroarch": [
+					"lutro"
+				]
+			}
+		]
+	},
+	{
+		"name": "openbor",
+		"fullname": "OpenBOR",
+		"category": "engine",
+		"extension": [
+			".pak"
+		],
+		"platform": "openbor",
+		"emulator": [
+			"openbor"
+		]
+	},
+	{
+		"name": "pico8",
+		"fullname": "PICO-8",
+		"category": "engine",
+		"extension": [
+			".p8",
+			".png"
+		],
+		"platform": "pico8",
+		"emulator": [
+			"pico8"
+		]
+	},
+	{
+		"name": "scummvm",
+		"fullname": "ScummVM",
+		"category": "engine",
+		"extension": [
+			".scummvm"
+		],
+		"platform": "scummvm",
+		"emulator": [
+			{
+				"retroarch": [
+					"scummvm"
+				]
+			},
+			"scummvm"
+		]
+	},
+	{
+		"name": "solarus",
+		"fullname": "Solarus",
+		"category": "engine",
+		"extension": [
+			".solarus"
+		],
+		"platform": "solarus",
+		"emulator": [
+			"solarus"
+		]
+	},
+	{
+		"name": "stratagus",
+		"fullname": "Stratagus",
+		"category": "engine",
+		"extension": [
+			".exe",
+			""
+		],
+		"platform": "stratagus",
+		"emulator": [
+			"stratagus"
+		]
+	},
+	{
+		"name": "tic80",
+		"fullname": "TIC-80",
+		"category": "engine",
+		"extension": [
+			".tic"
+		],
+		"platform": "tic80",
+		"emulator": [
+			{
+				"retroarch": [
+					"tic80"
+				]
+			},
+			"tic80"
+		]
+	},
+	{
+		"name": "3do",
+		"fullname": "3DO",
+		"category": "console",
+		"extension": [
+			".iso",
+			".bin",
+			".chd",
+			".cue",
+			".zip"
+		],
+		"platform": "3do",
+		"emulator": [
+			{
+				"retroarch": [
+					"opera"
+				]
+			},
+			"opera"
+		]
+	},
+	{
+		"name": "64dd",
+		"fullname": "Nintendo 64 DD",
+		"extends": "n64"
+	},
+	{
+		"name": "astrocade",
+		"fullname": "Bally Astrocade",
+		"extends": "arcade"
+	},
+	{
+		"name": "atari2600",
+		"fullname": "Atari 2600",
+		"category": "console",
+		"extension": [
+			".a26",
+			".bin",
+			".gz",
+			".rom",
+			".zip"
+		],
+		"platform": "atari2600",
+		"emulator": [
+			{
+				"retroarch": [
+					"stella"
+				]
+			},
+			"stella"
+		]
+	},
+	{
+		"name": "atari5200",
+		"fullname": "Atari 5200",
+		"category": "console",
+		"extends": "atari800"
+	},
+	{
+		"name": "atari7800",
+		"fullname": "Atari 7800",
+		"category": "console",
+		"extension": [
+			".a78",
+			".bin",
+			".zip"
+		],
+		"platform": "atari7800",
+		"emulator": [
+			{
+				"retroarch": [
+					"prosystem"
+				]
+			},
+			"prosystem",
+			"a7800"
+		]
+	},
+	{
+		"name": "atarijaguar",
+		"fullname": "Atari Jaguar",
+		"category": "console",
+		"extension": [
+			".j64",
+			".jag",
+			".rom",
+			".abs",
+			".cof",
+			".bin",
+			".prg"
+		],
+		"platform": "atarijaguar",
+		"emulator": [
+			{
+				"retroarch": [
+					"virtualjaguar"
+				]
+			},
+			"virtualjaguar"
+		]
+	},
+	{
+		"name": "atarijaguarcd",
+		"fullname": "Atari Jaguar CD",
+		"emulator": [
+			"project-tempest"
+		],
+		"extends": "atarijaguar"
+	},
+	{
+		"name": "atarilynx",
+		"fullname": "Atari Lynx",
+		"category": "console",
+		"extension": [
+			".lnx",
+			".o",
+			".zip"
+		],
+		"platform": "atarilynx",
+		"emulator": [
+			{
+				"retroarch": [
+					"handy",
+					"beetle-lynx"
+				]
+			},
+			"mednafen"
+		]
+	},
+	{
+		"name": "atarixe",
+		"fullname": "Atari XE",
+		"category": "console",
+		"extends": "atari800"
+	},
+	{
+		"name": "cdimono1",
+		"fullname": "Philips CD-i",
+		"category": "console",
+		"extension": [
+			".chd",
+			".cue",
+			".iso"
+		],
+		"platform": "cdimono1",
+		"emulator": [
+			{
+				"retroarch": [
+					"samecdi"
+				]
+			}
+		]
+	},
+	{
+		"name": "cdtv",
+		"fullname": "Commodore CDTV",
+		"category": "console",
+		"extends": "amiga"
+	},
+	{
+		"name": "channelf",
+		"fullname": "Fairchild Channel F",
+		"category": "console",
+		"extension": [
+			".bin",
+			".rom",
+			".chf",
+			".zip"
+		],
+		"platform": "channelf",
+		"emulator": [
+			{
+				"retroarch": [
+					"freechaf"
+				]
+			}
+		]
+	},
+	{
+		"name": "colecovision",
+		"fullname": "ColecoVision",
+		"category": "console",
+		"extension": [
+			".col",
+			".cv",
+			".bin",
+			".rom"
+		],
+		"platform": "colecovision",
+		"emulator": [
+			{
+				"retroarch": [
+					"bluemsx",
+					"gearcoleco"
+				]
+			},
+			"colem",
+			"dsp",
+			"ares",
+			"higan"
+		]
+	},
+	{
+		"name": "dreamcast",
+		"fullname": "Sega Dreamcast",
+		"category": "console",
+		"extension": [
+			".cdi",
+			".gdi",
+			".chd",
+			".cue",
+			".bin",
+			".elf",
+			".lst",
+			".dat",
+			".m3u",
+			".zip"
+		],
+		"platform": "dreamcast",
+		"emulator": [
+			{
+				"retroarch": [
+					"flycast"
+				]
+			},
+			"flycast",
+			"redream"
+		]
+	},
+	{
+		"name": "famicom",
+		"fullname": "Nintendo Family Computer",
+		"extends": "nes"
+	},
+	{
+		"name": "fds",
+		"fullname": "Nintendo Famicom Disk System",
+		"extends": "nes"
+	},
+	{
+		"name": "gameandwatch",
+		"fullname": "Nintendo Game & Watch",
+		"category": "console",
+		"extension": [
+			".mgw",
+			".zip"
+		],
+		"platform": "gameandwatch",
+		"emulator": [
+			{
+				"retroarch": [
+					"gw"
+				]
+			}
+		]
+	},
+	{
+		"name": "gamegear",
+		"fullname": "Sega Game Gear",
+		"extends": "mastersystem"
+	},
+	{
+		"name": "gb",
+		"fullname": "Nintendo Game Boy",
+		"category": "console",
+		"extension": [
+			".gb",
+			".gbc",
+			".bin",
+			".rom",
+			".dmg",
+			".cgb",
+			".sgb",
+			".zip"
+		],
+		"platform": "gb",
+		"emulator": [
+			{
+				"retroarch": [
+					"sameboy",
+					"gambatte",
+					"gearboy"
+				]
+			},
+			"sameboy",
+			"gambatte",
+			"gearboy"
+		]
+	},
+	{
+		"name": "gbc",
+		"fullname": "Nintendo Game Boy Color",
+		"extends": "gb"
+	},
+	{
+		"name": "gba",
+		"fullname": "Nintendo Game Boy Advance",
+		"category": "console",
+		"extension": [
+			".gba",
+			".agb",
+			".bin",
+			".zip"
+		],
+		"platform": "gba",
+		"emulator": [
+			{
+				"retroarch": [
+					"mgba",
+					"vba-m"
+				]
+			},
+			"mgba",
+			"vba-m"
+		]
+	},
+	{
+		"name": "gc",
+		"fullname": "Nintendo GameCube",
+		"category": "console",
+		"extension": [
+			".elf",
+			".iso",
+			".gcm",
+			".dol",
+			".tgc",
+			".wbfs",
+			".ciso",
+			".gcz",
+			".wad",
+			".rvz"
+		],
+		"platform": "gc",
+		"emulator": [
+			{
+				"retroarch": [
+					"dolphin"
+				]
+			},
+			"dolphin"
+		]
+	},
+	{
+		"name": "genesis",
+		"fullname": "Sega Genesis",
+		"category": "console",
+		"extension": [
+			".mdx",
+			".md",
+			".smd",
+			".gen",
+			".bin",
+			".cue",
+			".iso",
+			".sms",
+			".gg",
+			".sg",
+			".68k",
+			".chd",
+			".zip"
+		],
+		"platform": "genesis",
+		"emulator": [
+			{
+				"retroarch": [
+					"genesis-plus-gx",
+					"blastem",
+					"picodrive"
+				]
+			},
+			"blastem"
+		]
+	},
+	{
+		"name": "megadrive",
+		"fullname": "Sega Mega Drive",
+		"extends": "genesis"
+	},
+	{
+		"name": "sega32x",
+		"fullname": "Sega 32X",
+		"extends": "genesis"
+	},
+	{
+		"name": "segacd",
+		"fullname": "Sega CD",
+		"extends": "genesis"
+	},
+	{
+		"name": "gx4000",
+		"fullname": "Amstrad GX4000",
+		"extends": "amstradcpc"
+	},
+	{
+		"name": "intellivision",
+		"fullname": "Mattel Electronics Intellivision",
+		"category": "console",
+		"extension": [
+			".int",
+			".rom",
+			".bin",
+			".itv",
+			".zip"
+		],
+		"platform": "intellivision",
+		"emulator": [
+			{
+				"retroarch": [
+					"freeintv"
+				]
+			},
+			"freeintv",
+			"jzintv"
+		]
+	},
+	{
+		"name": "mastersystem",
+		"fullname": "Sega Master System",
+		"category": "console",
+		"extension": [
+			".sms",
+			".bin",
+			".rom",
+			".zip"
+		],
+		"platform": "mastersystem",
+		"emulator": [
+			{
+				"retroarch": [
+					"genesis-plus-gx",
+					"picodrive"
+				]
+			},
+			"emulicious"
+		]
+	},
+	{
+		"name": "multivision",
+		"fullname": "Othello Multivision",
+		"extends": "sg-1000"
+	},
+	{
+		"name": "n64",
+		"fullname": "Nintendo 64",
+		"category": "console",
+		"extension": [
+			".n64",
+			".v64",
+			".z64",
+			".bin",
+			".u1",
+			".ndd",
+			".zip"
+		],
+		"platform": "n64",
+		"emulator": [
+			{
+				"retroarch": [
+					"mupen64plus-next",
+					"parallel-n64"
+				]
+			},
+			"mupen64plus",
+			"project64"
+		]
+	},
+	{
+		"name": "nds",
+		"fullname": "Nintendo DS",
+		"category": "console",
+		"extension": [
+			".nds",
+			".bin"
+		],
+		"platform": "nds",
+		"emulator": [
+			{
+				"retroarch": [
+					"desmume",
+					"melonds"
+				]
+			},
+			"desmume",
+			"melonds"
+		]
+	},
+	{
+		"name": "neogeocd",
+		"fullname": "SNK Neo Geo CD",
+		"category": "console",
+		"emulator": [
+			{
+				"retroarch": [
+					"neocd",
+					"mame",
+					"fbneo"
+				]
+			},
+			"mame",
+			"fbneo"
+		],
+		"extends": "neogeo"
+	},
+	{
+		"name": "neogeocdjp",
+		"extends": "neogeocd"
 		},
-		{
-			"name": "ngp",
-			"fullname": "SNK Neo Geo Pocket",
-			"category": "console",
-			"extension": [
-				".ngp",
-				".ngc",
-				".zip"
-			],
-			"platform": "ngp",
-			"emulator": [
-				{
-					"retroarch": [
-						"beetle-ngp",
-						"race"
-					]
-				},
-				"ares",
-				"mednafen",
-				"higan"
-			]
-		},
-		{
-			"name": "ngpc",
-			"fullname": "SNK Neo Geo Pocket Color",
-			"extends": "ngp"
-		},
-		{
-			"name": "odyssey2",
-			"fullname": "Magnavox Odyssey²",
-			"category": "console",
-			"extension": [
-				".bin",
-				".zip"
-			],
-			"platform": "odyssey2",
-			"emulator": [
-				{
-					"retroarch": [
-						"o2em",
-						"mame"
-					]
-				},
-				"o2em",
-				"mame"
-			]
-		},
-		{
-			"name": "videopac",
-			"fullname": "Philips Videopac G7000",
-			"extends": "odyssey2"
-		},
-		{
-			"name": "tg16",
-			"fullname": "NEC TurboGrafx-16",
-			"category": "console",
-			"extension": [
-				".pce",
-				".sgx",
-				".cue",
-				".ccd",
-				".chd",
-				".iso",
-				".img",
-				".bin",
-				".zip"
-			],
-			"platform": "tg16",
-			"emulator": [
-				{
-					"retroarch": [
-						"beetle-supergrafx",
-						"beetle-pce-fast"
-					]
-				},
-				"mednafen"
-			]
-		},
-		{
-			"name": "tg-cd",
-			"fullname": "NEC TurboGrafx-CD",
-			"extends": "tg16"
-		},
-		{
-			"name": "pcengine",
-			"fullname": "NEC PC Engine",
-			"extends": "tg16"
-		},
-		{
-			"name": "pcenginecd",
-			"fullname": "NEC PC Engine CD",
-			"extends": "tg16"
-		},
-		{
-			"name": "pcfx",
-			"fullname": "NEC PC-FX",
-			"category": "console",
-			"extension": [
-				".cue",
-				".ccd",
-				".toc",
-				".chd"
-			],
-			"platform": "pcfx",
-			"emulator": [
-				{
-					"retroarch": [
-						"beetle-pc-fx"
-					]
-				},
-				"mednafen"
-			]
-		},
-		{
-			"name": "pokemini",
-			"fullname": "Nintendo Pokémon Mini",
-			"category": "console",
-			"extension": [
-				".min"
-			],
-			"platform": "pokemini",
-			"emulator": [
-				{
-					"retroarch": [
-						"pokemini"
-					]
-				},
-				"pokemini",
-				"gbe-plus"
-			]
-		},
-		{
-			"name": "ps2",
-			"fullname": "Sony PlayStation 2",
-			"category": "console",
-			"extension": [
-				".elf",
-				".iso",
-				".ciso",
-				".chd",
-				".cso",
-				".bin",
-				".mdf",
-				".nrg",
-				".dump",
-				".gz",
-				".img",
-				".m3u",
-				".z",
-				".z2",
-				".bz2",
-				".ima",
-				".zip"
-			],
-			"platform": "ps2",
-			"emulator": [
-				{
-					"retroarch": [
-						"pcsx2",
-						"play!"
-					]
-				},
-				"pcsx2",
-				"play!"
-			]
-		},
-		{
-			"name": "psx",
-			"fullname": "Sony PlayStation",
-			"category": "console",
-			"extension": [
-				".bin",
-				".cue",
-				".toc",
-				".m3u",
-				".ccd",
-				".exe",
-				".pbp",
-				".chd",
-				".img",
-				".mdf",
-				".cbn",
-				".iso",
-				".z",
-				".znx"
-			],
-			"platform": "psx",
-			"emulator": [
-				{
-					"retroarch": [
-						"duckstation",
-						"beetle-psx",
-						"beetle-psx-hw",
-						"pcsx-rearmed"
-					]
-				},
-				"duckstation",
-				"mednafen"
-			]
-		},
-		{
-			"name": "saturn",
-			"fullname": "Sega Saturn",
-			"category": "console",
-			"extension": [
-				".cue",
-				".toc",
-				".m3u",
-				".ccd",
-				".chd",
-				".iso",
-				".mds",
-				".zip"
-			],
-			"platform": "saturn",
-			"emulator": [
-				{
-					"retroarch": [
-						"beetle-saturn",
-						"beetle-saturn-hw",
-						"kronos",
-						"yabasanshiro",
-						"yabause"
-					]
-				},
-				"mednafen"
-			]
-		},
-		{
-			"name": "saturnjp",
-			"extends": "saturn"
-		},
-		{
-			"name": "snes",
-			"fullname": "Super Nintendo Entertainment System",
-			"category": "console",
-			"extension": [
-				".bin",
-				".bml",
-				".bs",
-				".bsx",
-				".dx2",
-				".fig",
-				".gd3",
-				".gd7",
-				".mgd",
-				".sfc",
-				".smc",
-				".st",
-				".swc",
-				".zip"
-			],
-			"platform": "snes",
-			"emulator": [
-				{
-					"retroarch": [
-						"snes9x",
-						"snes9x2010",
-						"bsnes",
-						"bsnes-hd",
-						"bsnes-mercury-accuracy",
-						"beetle-supafaust",
-						"mesen-s"
-					]
-				},
-				"snes9x",
-				"bsnes",
-				"mednafen"
-			]
-		},
-		{
-			"name": "sfc",
-			"fullname": "Nintendo Super Famicom",
-			"extends": "snes"
-		},
-		{
-			"name": "satellaview",
-			"fullname": "Nintendo Satellaview",
-			"extends": "snes"
-		},
-		{
-			"name": "sufami",
-			"fullname": "Bandai SuFami Turbo",
-			"extends": "snes"
-		},
-		{
-			"name": "sg-1000",
-			"fullname": "Sega SG-1000",
-			"category": "console",
-			"extension": [
-				".rom",
-				".ri",
-				".mx1",
-				".mx2",
-				".col",
-				".dsk",
-				".cas",
-				".sg",
-				".sc",
-				".m3u",
-				".bin",
-				".zip"
-			],
-			"platform": "sg-1000",
-			"emulator": [
-				{
-					"retroarch": [
-						"genesis-plus-gx",
-						"bluemsx"
-					]
-				},
-				"mastergear",
-				"ares",
-				"higan"
-			]
-		},
-		{
-			"name": "supergrafx",
-			"fullname": "NEC SuperGrafx",
-			"extends": "tg16"
-		},
-		{
-			"name": "uzebox",
-			"fullname": "Uzebox",
-			"category": "console",
-			"extension": [
-				".uze"
-			],
-			"platform": "uzebox",
-			"emulator": [
-				{
-					"retroarch": [
-						"uzem"
-					]
-				}
-			]
-		},
-		{
-			"name": "vectrex",
-			"fullname": "GCE Vectrex",
-			"category": "console",
-			"extension": [
-				".bin",
-				".vec",
-				".gam"
-			],
-			"platform": "vectrex",
-			"emulator": [
-				{
-					"retroarch": [
-						"vecx"
-					]
-				},
-				"parajve",
-				"vecx"
-			]
-		},
-		{
-			"name": "virtualboy",
-			"fullname": "Nintendo Virtual Boy",
-			"category": "console",
-			"extension": [
-				".vb",
-				".vboy",
-				".bin"
-			],
-			"platform": "virtualboy",
-			"emulator": [
-				{
-					"retroarch": [
-						"beetle-vb"
-					]
-				},
-				"mednafen"
-			]
-		},
-		{
-			"name": "wonderswan",
-			"fullname": "Bandai WonderSwan",
-			"category": "console",
-			"extension": [
-				".ws",
-				".wsc",
-				".pc2"
-			],
-			"platform": "wonderswan",
-			"emulator": [
-				{
-					"retroarch": [
-						"beetle-wswan"
-					]
-				},
-				"mednafen",
-				"ares",
-				"higan"
-			]
-		},
-		{
-			"name": "wonderswancolor",
-			"fullname": "Bandai WonderSwan Color",
-			"extends": "wonderswan"
-		},
-		{
-			"name": "xbox",
-			"fullname": "Microsoft Xbox",
-			"category": "console",
-			"extension": [
-				".iso"
-			],
-			"platform": "xbox",
-			"emulator": [
-				"xemu"
-			]
-		},
-		{
-			"name": "arcade",
-			"fullname": "Arcade",
-			"category": "arcade",
-			"extension": [
-				".chd",
-				".zip"
-			],
-			"platform": "arcade",
-			"emulator": [
-				{
-					"retroarch": [
-						"mame",
-						"mame2003-plus",
-						"mame2010"
-					]
-				},
-				"mame",
-				"dice"
-			]
-		},
-		{
-			"name": "atomiswave",
-			"fullname": "Atomiswave",
-			"category": "arcade",
-			"extends": "dreamcast"
-		},
-		{
-			"name": "daphne",
-			"fullname": "Daphne Arcade LaserDisc",
-			"category": "arcade",
-			"extension": [
-				".daphne"
-			],
-			"platform": "daphne",
-			"emulator": [
-				"daphne",
-				"hypseus"
-			]
-		},
-		{
-			"name": "fba",
-			"fullname": "FinalBurn Alpha",
-			"category": "arcade",
-			"extension": [
-				".iso",
-				".zip"
-			],
-			"platform": "fba",
-			"emulator": [
-				{
-					"retroarch": [
-						"fba2012"
-					]
-				}
-			]
-		},
-		{
-			"name": "fbneo",
-			"fullname": "FinalBurn Neo",
-			"category": "arcade",
-			"extension": [
-				".zip"
-			],
-			"platform": "fbneo",
-			"emulator": [
-				{
-					"retroarch": [
-						"fbneo"
-					]
-				}
-			]
-		},
-		{
-			"name": "mame",
-			"fullname": "Multiple Arcade Machine Emulator",
-			"category": "arcade",
-			"extension": [
-				".zip"
-			],
-			"platform": "mame",
-			"emulator": [
-				{
-					"retroarch": [
-						"mame",
-						"mame2003-plus",
-						"mame2010"
-					]
-				},
-				"mame"
-			]
-		},
-		{
-			"name": "naomi",
-			"fullname": "Sega NAOMI",
-			"category": "arcade",
-			"extends": "dreamcast"
-		},
-		{
-			"name": "naomigd",
-			"fullname": "Sega NAOMI GD-ROM",
-			"category": "arcade",
-			"extends": "dreamcast"
-		},
-		{
-			"name": "neogeo",
-			"fullname": "SNK Neo Geo",
-			"category": "arcade",
-			"extension": [
-				".zip"
-			],
-			"platform": "neogeo",
-			"emulator": [
-				{
-					"retroarch": [
-						"mame",
-						"fbneo",
-						"fba2012"
-					]
-				},
-				"mame",
-				"fbneo"
-			]
-		},
-		{
-			"name": "n3ds",
-			"fullname": "Nintendo 3DS",
-			"category": "modern_console",
-			"extension": [
-				".3ds",
-				".3dsx",
-				".elf",
-				".axf",
-				".cci",
-				".cxi",
-				".app"
-			],
-			"platform": "n3ds",
-			"emulator": [
-				{
-					"retroarch": [
-						"citra"
-					]
-				},
-				"citra"
-			]
-		},
-		{
-			"name": "ps3",
-			"fullname": "Sony PlayStation 3",
-			"category": "modern_console",
-			"extension": [
-				".self",
-				".elf",
-				".pkg",
-				".iso"
-			],
-			"platform": "ps3",
-			"emulator": [
-				"rpcs3"
-			]
-		},
-		{
-			"name": "psp",
-			"fullname": "Sony PlayStation Portable",
-			"category": "modern_console",
-			"extension": [
-				".elf",
-				".iso",
-				".cso",
-				".prx",
-				".pbp"
-			],
-			"platform": "psp",
-			"emulator": [
-				{
-					"retroarch": [
-						"ppsspp"
-					]
-				},
-				"ppsspp"
-			]
-		},
-		{
-			"name": "psvita",
-			"fullname": "Sony PlayStation Vita",
-			"category": "modern_console",
-			"extension": [
-				".vpk"
-			],
-			"platform": "psvita",
-			"emulator": [
-				"vita3k"
-			]
-		},
-		{
-			"name": "switch",
-			"fullname": "Nintendo Switch",
-			"category": "modern_console",
-			"extension": [
-				".nca",
-				".nro",
-				".nso",
-				".nsp",
-				".xci"
-			],
-			"platform": "switch",
-			"emulator": [
-				"yuzu",
-				"ryujinx"
-			]
-		},
-		{
-			"name": "wii",
-			"fullname": "Nintendo Wii",
-			"category": "modern_console",
-			"extends": "gc"
-		},
-		{
-			"name": "wiiu",
-			"fullname": "Nintendo Wii U",
-			"category": "modern_console",
-			"extension": [
-				".wud",
-				".wux",
-				".rpx"
-			],
-			"platform": "wiiu",
-			"emulator": [
-				"cemu"
-			]
-		},
-		{
-			"name": "xbox360",
-			"fullname": "Microsoft Xbox 360",
-			"category": "modern_console",
-			"extension": [
-				".xex"
-			],
-			"platform": "xbox360",
-			"emulator": [
-				"xenia"
-			]
-		}
-	]
-}
+	{
+		"name": "nes",
+		"fullname": "Nintendo Entertainment System",
+		"category": "console",
+		"extension": [
+			".nes",
+			".fds",
+			".unf",
+			".unif",
+			".zip"
+		],
+		"platform": "nes",
+		"emulator": [
+			{
+				"retroarch": [
+					"nestopia",
+					"fceumm",
+					"mesen",
+					"quicknes"
+				]
+			},
+			"mesen",
+			"punes",
+			"nestopia"
+		]
+	},
+	{
+		"name": "ngp",
+		"fullname": "SNK Neo Geo Pocket",
+		"category": "console",
+		"extension": [
+			".ngp",
+			".ngc",
+			".zip"
+		],
+		"platform": "ngp",
+		"emulator": [
+			{
+				"retroarch": [
+					"beetle-ngp",
+					"race"
+				]
+			},
+			"ares",
+			"mednafen",
+			"higan"
+		]
+	},
+	{
+		"name": "ngpc",
+		"fullname": "SNK Neo Geo Pocket Color",
+		"extends": "ngp"
+	},
+	{
+		"name": "odyssey2",
+		"fullname": "Magnavox Odyssey²",
+		"category": "console",
+		"extension": [
+			".bin",
+			".zip"
+		],
+		"platform": "odyssey2",
+		"emulator": [
+			{
+				"retroarch": [
+					"o2em",
+					"mame"
+				]
+			},
+			"o2em",
+			"mame"
+		]
+	},
+	{
+		"name": "videopac",
+		"fullname": "Philips Videopac G7000",
+		"extends": "odyssey2"
+	},
+	{
+		"name": "tg16",
+		"fullname": "NEC TurboGrafx-16",
+		"category": "console",
+		"extension": [
+			".pce",
+			".sgx",
+			".cue",
+			".ccd",
+			".chd",
+			".iso",
+			".img",
+			".bin",
+			".zip"
+		],
+		"platform": "tg16",
+		"emulator": [
+			{
+				"retroarch": [
+					"beetle-supergrafx",
+					"beetle-pce-fast"
+				]
+			},
+			"mednafen"
+		]
+	},
+	{
+		"name": "tg-cd",
+		"fullname": "NEC TurboGrafx-CD",
+		"extends": "tg16"
+	},
+	{
+		"name": "pcengine",
+		"fullname": "NEC PC Engine",
+		"extends": "tg16"
+	},
+	{
+		"name": "pcenginecd",
+		"fullname": "NEC PC Engine CD",
+		"extends": "tg16"
+	},
+	{
+		"name": "pcfx",
+		"fullname": "NEC PC-FX",
+		"category": "console",
+		"extension": [
+			".cue",
+			".ccd",
+			".toc",
+			".chd"
+		],
+		"platform": "pcfx",
+		"emulator": [
+			{
+				"retroarch": [
+					"beetle-pc-fx"
+				]
+			},
+			"mednafen"
+		]
+	},
+	{
+		"name": "pokemini",
+		"fullname": "Nintendo Pokémon Mini",
+		"category": "console",
+		"extension": [
+			".min"
+		],
+		"platform": "pokemini",
+		"emulator": [
+			{
+				"retroarch": [
+					"pokemini"
+				]
+			},
+			"pokemini",
+			"gbe-plus"
+		]
+	},
+	{
+		"name": "ps2",
+		"fullname": "Sony PlayStation 2",
+		"category": "console",
+		"extension": [
+			".elf",
+			".iso",
+			".ciso",
+			".chd",
+			".cso",
+			".bin",
+			".mdf",
+			".nrg",
+			".dump",
+			".gz",
+			".img",
+			".m3u",
+			".z",
+			".z2",
+			".bz2",
+			".ima",
+			".zip"
+		],
+		"platform": "ps2",
+		"emulator": [
+			{
+				"retroarch": [
+					"pcsx2",
+					"play!"
+				]
+			},
+			"pcsx2",
+			"play!"
+		]
+	},
+	{
+		"name": "psx",
+		"fullname": "Sony PlayStation",
+		"category": "console",
+		"extension": [
+			".bin",
+			".cue",
+			".toc",
+			".m3u",
+			".ccd",
+			".exe",
+			".pbp",
+			".chd",
+			".img",
+			".mdf",
+			".cbn",
+			".iso",
+			".z",
+			".znx"
+		],
+		"platform": "psx",
+		"emulator": [
+			{
+				"retroarch": [
+					"duckstation",
+					"beetle-psx",
+					"beetle-psx-hw",
+					"pcsx-rearmed"
+				]
+			},
+			"duckstation",
+			"mednafen"
+		]
+	},
+	{
+		"name": "saturn",
+		"fullname": "Sega Saturn",
+		"category": "console",
+		"extension": [
+			".cue",
+			".toc",
+			".m3u",
+			".ccd",
+			".chd",
+			".iso",
+			".mds",
+			".zip"
+		],
+		"platform": "saturn",
+		"emulator": [
+			{
+				"retroarch": [
+					"beetle-saturn",
+					"beetle-saturn-hw",
+					"kronos",
+					"yabasanshiro",
+					"yabause"
+				]
+			},
+			"mednafen"
+		]
+	},
+	{
+		"name": "saturnjp",
+		"extends": "saturn"
+	},
+	{
+		"name": "snes",
+		"fullname": "Super Nintendo Entertainment System",
+		"category": "console",
+		"extension": [
+			".bin",
+			".bml",
+			".bs",
+			".bsx",
+			".dx2",
+			".fig",
+			".gd3",
+			".gd7",
+			".mgd",
+			".sfc",
+			".smc",
+			".st",
+			".swc",
+			".zip"
+		],
+		"platform": "snes",
+		"emulator": [
+			{
+				"retroarch": [
+					"snes9x",
+					"snes9x2010",
+					"bsnes",
+					"bsnes-hd",
+					"bsnes-mercury-accuracy",
+					"beetle-supafaust",
+					"mesen-s"
+				]
+			},
+			"snes9x",
+			"bsnes",
+			"mednafen"
+		]
+	},
+	{
+		"name": "sfc",
+		"fullname": "Nintendo Super Famicom",
+		"extends": "snes"
+	},
+	{
+		"name": "satellaview",
+		"fullname": "Nintendo Satellaview",
+		"extends": "snes"
+	},
+	{
+		"name": "sufami",
+		"fullname": "Bandai SuFami Turbo",
+		"extends": "snes"
+	},
+	{
+		"name": "sg-1000",
+		"fullname": "Sega SG-1000",
+		"category": "console",
+		"extension": [
+			".rom",
+			".ri",
+			".mx1",
+			".mx2",
+			".col",
+			".dsk",
+			".cas",
+			".sg",
+			".sc",
+			".m3u",
+			".bin",
+			".zip"
+		],
+		"platform": "sg-1000",
+		"emulator": [
+			{
+				"retroarch": [
+					"genesis-plus-gx",
+					"bluemsx"
+				]
+			},
+			"mastergear",
+			"ares",
+			"higan"
+		]
+	},
+	{
+		"name": "supergrafx",
+		"fullname": "NEC SuperGrafx",
+		"extends": "tg16"
+	},
+	{
+		"name": "uzebox",
+		"fullname": "Uzebox",
+		"category": "console",
+		"extension": [
+			".uze"
+		],
+		"platform": "uzebox",
+		"emulator": [
+			{
+				"retroarch": [
+					"uzem"
+				]
+			}
+		]
+	},
+	{
+		"name": "vectrex",
+		"fullname": "GCE Vectrex",
+		"category": "console",
+		"extension": [
+			".bin",
+			".vec",
+			".gam"
+		],
+		"platform": "vectrex",
+		"emulator": [
+			{
+				"retroarch": [
+					"vecx"
+				]
+			},
+			"parajve",
+			"vecx"
+		]
+	},
+	{
+		"name": "virtualboy",
+		"fullname": "Nintendo Virtual Boy",
+		"category": "console",
+		"extension": [
+			".vb",
+			".vboy",
+			".bin"
+		],
+		"platform": "virtualboy",
+		"emulator": [
+			{
+				"retroarch": [
+					"beetle-vb"
+				]
+			},
+			"mednafen"
+		]
+	},
+	{
+		"name": "wonderswan",
+		"fullname": "Bandai WonderSwan",
+		"category": "console",
+		"extension": [
+			".ws",
+			".wsc",
+			".pc2"
+		],
+		"platform": "wonderswan",
+		"emulator": [
+			{
+				"retroarch": [
+					"beetle-wswan"
+				]
+			},
+			"mednafen",
+			"ares",
+			"higan"
+		]
+	},
+	{
+		"name": "wonderswancolor",
+		"fullname": "Bandai WonderSwan Color",
+		"extends": "wonderswan"
+	},
+	{
+		"name": "xbox",
+		"fullname": "Microsoft Xbox",
+		"category": "console",
+		"extension": [
+			".iso"
+		],
+		"platform": "xbox",
+		"emulator": [
+			"xemu"
+		]
+	},
+	{
+		"name": "arcade",
+		"fullname": "Arcade",
+		"category": "arcade",
+		"extension": [
+			".chd",
+			".zip"
+		],
+		"platform": "arcade",
+		"emulator": [
+			{
+				"retroarch": [
+					"mame",
+					"mame2003-plus",
+					"mame2010"
+				]
+			},
+			"mame",
+			"dice"
+		]
+	},
+	{
+		"name": "atomiswave",
+		"fullname": "Atomiswave",
+		"category": "arcade",
+		"extends": "dreamcast"
+	},
+	{
+		"name": "daphne",
+		"fullname": "Daphne Arcade LaserDisc",
+		"category": "arcade",
+		"extension": [
+			".daphne"
+		],
+		"platform": "daphne",
+		"emulator": [
+			"daphne",
+			"hypseus"
+		]
+	},
+	{
+		"name": "fba",
+		"fullname": "FinalBurn Alpha",
+		"category": "arcade",
+		"extension": [
+			".iso",
+			".zip"
+		],
+		"platform": "fba",
+		"emulator": [
+			{
+				"retroarch": [
+					"fba2012"
+				]
+			}
+		]
+	},
+	{
+		"name": "fbneo",
+		"fullname": "FinalBurn Neo",
+		"category": "arcade",
+		"extension": [
+			".zip"
+		],
+		"platform": "fbneo",
+		"emulator": [
+			{
+				"retroarch": [
+					"fbneo"
+				]
+			}
+		]
+	},
+	{
+		"name": "mame",
+		"fullname": "Multiple Arcade Machine Emulator",
+		"category": "arcade",
+		"extension": [
+			".zip"
+		],
+		"platform": "mame",
+		"emulator": [
+			{
+				"retroarch": [
+					"mame",
+					"mame2003-plus",
+					"mame2010"
+				]
+			},
+			"mame"
+		]
+	},
+	{
+		"name": "naomi",
+		"fullname": "Sega NAOMI",
+		"category": "arcade",
+		"extends": "dreamcast"
+	},
+	{
+		"name": "naomigd",
+		"fullname": "Sega NAOMI GD-ROM",
+		"category": "arcade",
+		"extends": "dreamcast"
+	},
+	{
+		"name": "neogeo",
+		"fullname": "SNK Neo Geo",
+		"category": "arcade",
+		"extension": [
+			".zip"
+		],
+		"platform": "neogeo",
+		"emulator": [
+			{
+				"retroarch": [
+					"mame",
+					"fbneo",
+					"fba2012"
+				]
+			},
+			"mame",
+			"fbneo"
+		]
+	},
+	{
+		"name": "n3ds",
+		"fullname": "Nintendo 3DS",
+		"category": "modern_console",
+		"extension": [
+			".3ds",
+			".3dsx",
+			".elf",
+			".axf",
+			".cci",
+			".cxi",
+			".app"
+		],
+		"platform": "n3ds",
+		"emulator": [
+			{
+				"retroarch": [
+					"citra"
+				]
+			},
+			"citra"
+		]
+	},
+	{
+		"name": "ps3",
+		"fullname": "Sony PlayStation 3",
+		"category": "modern_console",
+		"extension": [
+			".self",
+			".elf",
+			".pkg",
+			".iso"
+		],
+		"platform": "ps3",
+		"emulator": [
+			"rpcs3"
+		]
+	},
+	{
+		"name": "psp",
+		"fullname": "Sony PlayStation Portable",
+		"category": "modern_console",
+		"extension": [
+			".elf",
+			".iso",
+			".cso",
+			".prx",
+			".pbp"
+		],
+		"platform": "psp",
+		"emulator": [
+			{
+				"retroarch": [
+					"ppsspp"
+				]
+			},
+			"ppsspp"
+		]
+	},
+	{
+		"name": "psvita",
+		"fullname": "Sony PlayStation Vita",
+		"category": "modern_console",
+		"extension": [
+			".vpk"
+		],
+		"platform": "psvita",
+		"emulator": [
+			"vita3k"
+		]
+	},
+	{
+		"name": "switch",
+		"fullname": "Nintendo Switch",
+		"category": "modern_console",
+		"extension": [
+			".nca",
+			".nro",
+			".nso",
+			".nsp",
+			".xci"
+		],
+		"platform": "switch",
+		"emulator": [
+			"yuzu",
+			"ryujinx"
+		]
+	},
+	{
+		"name": "wii",
+		"fullname": "Nintendo Wii",
+		"category": "modern_console",
+		"extends": "gc"
+	},
+	{
+		"name": "wiiu",
+		"fullname": "Nintendo Wii U",
+		"category": "modern_console",
+		"extension": [
+			".wud",
+			".wux",
+			".rpx"
+		],
+		"platform": "wiiu",
+		"emulator": [
+			"cemu"
+		]
+	},
+	{
+		"name": "xbox360",
+		"fullname": "Microsoft Xbox 360",
+		"category": "modern_console",
+		"extension": [
+			".xex"
+		],
+		"platform": "xbox360",
+		"emulator": [
+			"xenia"
+		]
+	}
+]

--- a/resources/controller_mapper/Mapper.gd
+++ b/resources/controller_mapper/Mapper.gd
@@ -1,6 +1,9 @@
 extends ControllerMapper
 
 func _convert_joypad_path(path: String, fallback: int) -> String:
+	if Engine.editor_hint:
+		return ._convert_joypad_path(path, fallback)
+
 	match RetroHubConfig.config.input_controller_icon_type:
 		1: # Xbox 360
 			return ._convert_joypad_to_xbox360(path)

--- a/scenes/root/popups/first_time/EmulatorsSection.gd
+++ b/scenes/root/popups/first_time/EmulatorsSection.gd
@@ -7,6 +7,9 @@ onready var n_emulator_info_tab := $"%EmulatorInfoTab"
 
 var icon_cache := {}
 
+func _ready():
+	n_systems.get_popup().max_height = 350
+
 func grab_focus():
 	n_systems.grab_focus()
 	set_systems()

--- a/scenes/root/popups/first_time/EmulatorsSection.tscn
+++ b/scenes/root/popups/first_time/EmulatorsSection.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource path="res://scenes/root/popups/first_time/EmulatorsSection.gd" type="Script" id=1]
 [ext_resource path="res://addons/controller_icons/objects/TextureRect.gd" type="Script" id=2]
-[ext_resource path="res://addons/controller_icons/assets/xboxone/r_stick.png" type="Texture" id=3]
+[ext_resource path="res://addons/controller_icons/assets/xbox360/r_stick.png" type="Texture" id=3]
 
 [node name="EmulatorsSection" type="Control"]
 anchor_right = 1.0

--- a/scenes/root/popups/first_time/FirstTimePopups.tscn
+++ b/scenes/root/popups/first_time/FirstTimePopups.tscn
@@ -18,6 +18,7 @@
 [ext_resource path="res://scenes/root/popups/first_time/EmulatorsSection.tscn" type="PackedScene" id=17]
 
 [node name="FirstTimePopup" type="Popup"]
+visible = true
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 28.0

--- a/scenes/root/popups/first_time/ImportSettingsSection.gd
+++ b/scenes/root/popups/first_time/ImportSettingsSection.gd
@@ -15,6 +15,9 @@ onready var importers = [
 var thread := Thread.new()
 var importer_support := []
 
+func _ready():
+	n_import_options.get_popup().max_height = 350
+
 func grab_focus():
 	n_import_options.grab_focus()
 	query_importers()

--- a/source/data/ConfigData.gd
+++ b/source/data/ConfigData.gd
@@ -194,7 +194,7 @@ func load_config_from_path(path: String) -> int:
 	if(json_result.error):
 		print("Error parsing config file!")
 		return ERR_FILE_CORRUPT
-	
+
 	# Dictionary ready for retrieval
 	_old_config = json_result.result
 
@@ -217,7 +217,7 @@ func save_config_to_path(path: String, force_save: bool = false) -> int:
 	if(file.open(path, File.WRITE)):
 		print("Error opening config file " + path + "for saving!")
 		return ERR_CANT_OPEN
-	
+
 	# Construct dict and save config
 	var dict = {}
 	for key in _keys:

--- a/source/utils/JSONUtils.gd
+++ b/source/utils/JSONUtils.gd
@@ -1,6 +1,6 @@
 extends Node
 
-func load_json_file(filepath : String) -> Dictionary:
+func load_json_file(filepath : String):
 	var file = File.new()
 	if file.open(filepath, File.READ):
 		print("Error when opening " + filepath)
@@ -11,41 +11,31 @@ func load_json_file(filepath : String) -> Dictionary:
 		return {}
 	return json.result
 
-func make_system_specific(input_json: Dictionary, curr_system: String):
-	var output_json := {}
+func make_system_specific(json: Dictionary, curr_system: String):
 	
-	for key in input_json.keys():
-		var value = input_json[key]
+	for key in json.keys():
+		var value = json[key]
 		if value is Array:
 			# Possibly the thing we are looking for, test further
 			if value.size() and value[0] is Dictionary and value[0].has("windows"):
-				# Found system-specific data, now find appropriate child
-				var system_data = null
+				# Found system-specific data
+				var found := false
 				for system in value:
 					if system.has(curr_system):
-						system_data = system[curr_system]
+						json[key] = system[curr_system]
+						found = true
 						break
 				
-				if system_data != null:
-					output_json[key] = system_data
-				else:
+				if not found:
 					print("Error, JSON doesn't have required system, leaving as is...")
-					output_json[key] = value
 			else:
 				# Not what we're looking for, recurse it
-				output_json[key] = []
 				for arr_value in value:
 					if arr_value is Dictionary:
-						output_json[key].append(make_system_specific(arr_value, curr_system))
-					else:
-						output_json[key].append(arr_value)
+						make_system_specific(arr_value, curr_system)
 		# Not what we're looking for, append to output
 		elif value is Dictionary:
-			output_json[key] = make_system_specific(value, curr_system)
-		else:
-			output_json[key] = value
-	
-	return output_json
+			make_system_specific(value, curr_system)
 
 func find_by_key(input_arr: Array, key: String, values: Array) -> Dictionary:
 	for val in values:


### PR DESCRIPTION
Closes #90 

`rh_systems`/`rh_emulators` no longer reflect the full system/emulator information, but are rather custom modifications to
default information. It is still possible to remove default systems, although with this change there's no longer the possibility of defining a default system outside of RetroHub.

Along with it are the removal of `systems_list`/`emulators_list`, and so the info files start as an array immediately.

This is a breaking change due to the removal of the `systems_list`/`emulators_list`. It could easily be handled in existing configs, but since this is still in alpha it's not a problem anyways.

Other than that, some bugfixes and fix some usability issues (also from Godot fork).