### PR TITLE
Implement basic emulator editor UI

### DIFF
--- a/scenes/root/popups/config/ConfigPopup.tscn
+++ b/scenes/root/popups/config/ConfigPopup.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://scenes/root/popups/config/ConfigPopup.gd" type="Script" id=1]
 [ext_resource path="res://assets/icons/first_time/region.svg" type="Texture" id=2]
@@ -14,9 +14,9 @@
 [ext_resource path="res://scenes/root/popups/config/settings/RegionSettings.tscn" type="PackedScene" id=12]
 [ext_resource path="res://scenes/root/popups/config/QuitSettings.tscn" type="PackedScene" id=13]
 [ext_resource path="res://scenes/root/popups/config/settings/SystemSettings.tscn" type="PackedScene" id=14]
+[ext_resource path="res://scenes/root/popups/config/settings/EmulatorSettings.tscn" type="PackedScene" id=15]
 
 [node name="ConfigPopup" type="PopupPanel"]
-visible = true
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -45,7 +45,7 @@ follow_focus = true
 scroll_horizontal_enabled = false
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer/ScrollContainer"]
-margin_right = 118.0
+margin_right = 130.0
 margin_bottom = 766.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -152,7 +152,6 @@ size_flags_vertical = 3
 tabs_visible = false
 
 [node name="QuitSettings" parent="HBoxContainer/SettingsTab" instance=ExtResource( 13 )]
-visible = false
 margin_left = 5.0
 margin_top = 5.0
 margin_right = -5.0
@@ -211,6 +210,7 @@ margin_right = -5.0
 margin_bottom = -5.0
 
 [node name="SystemSettings" parent="HBoxContainer/SettingsTab" instance=ExtResource( 14 )]
+visible = false
 margin_left = 5.0
 margin_top = 5.0
 margin_right = -5.0
@@ -218,17 +218,8 @@ margin_bottom = -5.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="EmulatorsSettings" type="Label" parent="HBoxContainer/SettingsTab"]
+[node name="EmulatorSettings" parent="HBoxContainer/SettingsTab" instance=ExtResource( 15 )]
 visible = false
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 5.0
-margin_top = 5.0
-margin_right = -5.0
-margin_bottom = -5.0
-text = "To be implemented"
-align = 1
-valign = 1
 
 [node name="About" type="Label" parent="HBoxContainer/SettingsTab"]
 visible = false

--- a/scenes/root/popups/config/settings/EmulatorSettings.gd
+++ b/scenes/root/popups/config/settings/EmulatorSettings.gd
@@ -1,0 +1,84 @@
+extends Control
+
+signal theme_reload()
+
+onready var n_save := $"%Save"
+onready var n_discard := $"%Discard"
+onready var n_emulator_selection := $"%EmulatorSelection"
+onready var n_emulator_editor := $"%EmulatorEditor"
+onready var n_default_opt := $"%DefaultOptions"
+onready var n_custom_opt := $"%CustomOptions"
+onready var n_restore_emulator := $"%RestoreEmulator"
+
+func _ready():
+	n_emulator_selection.get_popup().max_height = 350
+	RetroHubConfig.connect("config_ready", self, "_on_config_ready")
+	n_save.disabled = true
+	n_discard.disabled = true
+	n_default_opt.visible = false
+	n_custom_opt.visible = false
+
+func grab_focus():
+	n_emulator_selection.grab_focus()
+
+func _on_config_ready(config_data: ConfigData):
+	var idx = 0
+	for emulator in RetroHubConfig.emulators_map.values():
+		if not emulator.has("#custom"):
+			n_emulator_selection.add_item("[%s] %s" % [emulator["name"], emulator["fullname"]], idx)
+			n_emulator_selection.set_item_metadata(idx, emulator)
+			idx += 1
+
+func _on_EmulatorSelection_item_selected(index):
+	var data : Dictionary = n_emulator_selection.get_item_metadata(index)
+	discard_changes()
+	var is_custom = data.has("#custom")
+	n_default_opt.visible = !is_custom
+	n_custom_opt.visible = is_custom
+	n_restore_emulator.disabled = not data.has("#modified")
+	n_emulator_editor.curr_emulator = data
+
+
+func _on_EmulatorSettings_visibility_changed():
+	if n_emulator_selection and n_emulator_editor:
+		if visible:
+			_on_EmulatorSelection_item_selected(n_emulator_selection.selected)
+		else:
+			n_emulator_editor.clear_icons()
+
+
+func _on_EmulatorEditor_change_ocurred():
+	n_save.disabled = false
+	n_discard.disabled = false
+
+
+func save_changes():
+	var emulator_raw : Dictionary = n_emulator_editor.save()
+	RetroHubConfig.save_emulator(emulator_raw)
+	update_emulator_selection(emulator_raw)
+	emit_signal("theme_reload")
+	n_save.disabled = true
+	n_discard.disabled = true
+	n_restore_emulator.disabled = false
+
+func discard_changes():
+	n_emulator_editor.reset()
+	n_save.disabled = true
+	n_discard.disabled = true
+
+
+func _on_RestoreEmulator_pressed():
+	var default_emulator = RetroHubConfig.restore_emulator(n_emulator_editor.curr_emulator)
+	n_emulator_editor.curr_emulator = default_emulator
+	update_emulator_selection(default_emulator)
+	emit_signal("theme_reload")
+	n_save.disabled = true
+	n_discard.disabled = true
+	n_restore_emulator.disabled = true
+
+func update_emulator_selection(emulator: Dictionary):
+	for idx in range(n_emulator_selection.get_item_count()):
+		if n_emulator_selection.get_item_metadata(idx)["name"] == emulator["name"]:
+			n_emulator_selection.set_item_text(idx, "[%s] %s" % [emulator["name"], emulator["fullname"]])
+			n_emulator_selection.set_item_metadata(idx, emulator)
+			return

--- a/scenes/root/popups/config/settings/EmulatorSettings.tscn
+++ b/scenes/root/popups/config/settings/EmulatorSettings.tscn
@@ -1,0 +1,111 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://scenes/root/popups/config/settings/emulator/EmulatorEditor.tscn" type="PackedScene" id=1]
+[ext_resource path="res://scenes/root/popups/config/settings/EmulatorSettings.gd" type="Script" id=2]
+
+[node name="EmulatorSettings" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 2 )
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+margin_right = 1024.0
+margin_bottom = 20.0
+
+[node name="EmulatorSelection" type="OptionButton" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+margin_right = 803.0
+margin_bottom = 20.0
+focus_neighbour_bottom = NodePath("../../HBoxContainer2/AddEmulator")
+size_flags_horizontal = 3
+expand_icon = true
+
+[node name="Save" type="Button" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+margin_left = 807.0
+margin_right = 904.0
+margin_bottom = 20.0
+text = "Save changes"
+
+[node name="Discard" type="Button" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+margin_left = 908.0
+margin_right = 1024.0
+margin_bottom = 20.0
+text = "Discard changes"
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 24.0
+margin_right = 1024.0
+margin_bottom = 44.0
+
+[node name="AddEmulator" type="Button" parent="VBoxContainer/HBoxContainer2"]
+margin_left = 508.0
+margin_right = 659.0
+margin_bottom = 20.0
+size_flags_horizontal = 10
+text = "Add custom emulator"
+
+[node name="VSeparator" type="VSeparator" parent="VBoxContainer/HBoxContainer2"]
+margin_left = 663.0
+margin_right = 667.0
+margin_bottom = 20.0
+
+[node name="DefaultOptions" type="HBoxContainer" parent="VBoxContainer/HBoxContainer2"]
+unique_name_in_owner = true
+margin_left = 671.0
+margin_right = 842.0
+margin_bottom = 20.0
+
+[node name="RestoreEmulator" type="Button" parent="VBoxContainer/HBoxContainer2/DefaultOptions"]
+unique_name_in_owner = true
+margin_right = 171.0
+margin_bottom = 20.0
+text = "Restore default emulator"
+
+[node name="CustomOptions" type="HBoxContainer" parent="VBoxContainer/HBoxContainer2"]
+unique_name_in_owner = true
+margin_left = 846.0
+margin_right = 1024.0
+margin_bottom = 20.0
+
+[node name="RemoveEmulator" type="Button" parent="VBoxContainer/HBoxContainer2/CustomOptions"]
+margin_right = 178.0
+margin_bottom = 20.0
+text = "Remove custom emulator"
+
+[node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
+margin_top = 48.0
+margin_right = 1024.0
+margin_bottom = 52.0
+
+[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer"]
+margin_top = 56.0
+margin_right = 1024.0
+margin_bottom = 600.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+follow_focus = true
+scroll_horizontal_enabled = false
+
+[node name="EmulatorEditor" parent="VBoxContainer/ScrollContainer" instance=ExtResource( 1 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 1024.0
+margin_bottom = 544.0
+
+[connection signal="visibility_changed" from="." to="." method="_on_EmulatorSettings_visibility_changed"]
+[connection signal="item_selected" from="VBoxContainer/HBoxContainer/EmulatorSelection" to="." method="_on_EmulatorSelection_item_selected"]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/Save" to="." method="save_changes"]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/Discard" to="." method="discard_changes"]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer2/DefaultOptions/RestoreEmulator" to="." method="_on_RestoreEmulator_pressed"]
+[connection signal="change_ocurred" from="VBoxContainer/ScrollContainer/EmulatorEditor" to="." method="_on_EmulatorEditor_change_ocurred"]
+
+[editable path="VBoxContainer/ScrollContainer/EmulatorEditor"]

--- a/scenes/root/popups/config/settings/emulator/EmulatorEditor.gd
+++ b/scenes/root/popups/config/settings/emulator/EmulatorEditor.gd
@@ -1,0 +1,57 @@
+extends Control
+
+signal change_ocurred()
+
+var curr_emulator : Dictionary setget set_curr_emulator
+
+onready var n_logo := $"%Logo"
+onready var n_name := $"%Identifier"
+onready var n_fullname := $"%Name"
+onready var n_path := $"%Path"
+onready var n_command := $"%Command"
+
+func set_curr_emulator(_curr_emulator: Dictionary):
+	curr_emulator = _curr_emulator
+	n_logo.icon = load("res://assets/emulators/%s.png" % curr_emulator["name"])
+	n_logo.text = "<click to add>" if not n_logo.icon else ""
+	n_name.text = curr_emulator["name"]
+	n_fullname.text = curr_emulator["fullname"]
+	n_path.text = RetroHubGenericEmulator.find_and_substitute_str(curr_emulator["binpath"], {})
+	n_command.text = curr_emulator["command"]
+
+func save() -> Dictionary:
+	curr_emulator["fullname"] = n_fullname.text
+	curr_emulator["binpath"] = n_path.text
+	curr_emulator["command"] = n_command.text
+
+	return curr_emulator
+
+func reset():
+	if curr_emulator:
+		set_curr_emulator(curr_emulator)
+
+func clear_icons():
+	n_logo.icon = null
+
+func _on_item_change(__):
+	emit_signal("change_ocurred")
+
+func _on_VarButton_pressed(variable: String):
+	emit_signal("change_ocurred")
+	var curr_pos : int = n_command.caret_position
+	n_command.text = n_command.text.substr(0, curr_pos) + variable + n_command.text.substr(curr_pos)
+	n_command.caret_position = curr_pos + variable.length()
+
+
+func _on_LoadPath_pressed():
+	match FileUtils.get_os_id():
+		FileUtils.OS_ID.WINDOWS:
+			RetroHubUI.filesystem_filters(["*.exe ; Executable Files"])
+			RetroHubUI.request_file_load("C://")
+		_:
+			RetroHubUI.filesystem_filters([])
+			RetroHubUI.request_file_load("/bin")
+	var path : String = yield(RetroHubUI, "path_selected")
+	if not path.empty():
+		n_path.text = path
+		emit_signal("change_ocurred")

--- a/scenes/root/popups/config/settings/emulator/EmulatorEditor.tscn
+++ b/scenes/root/popups/config/settings/emulator/EmulatorEditor.tscn
@@ -1,0 +1,181 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://scenes/root/popups/config/settings/emulator/EmulatorEditor.gd" type="Script" id=1]
+[ext_resource path="res://assets/icons/load.svg" type="Texture" id=2]
+
+[node name="EmulatorEditor" type="VBoxContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+focus_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource( 1 )
+
+[node name="Label" type="Label" parent="."]
+margin_right = 1024.0
+margin_bottom = 14.0
+text = "Logo:"
+
+[node name="Logo" type="Button" parent="."]
+unique_name_in_owner = true
+margin_top = 18.0
+margin_right = 80.0
+margin_bottom = 98.0
+rect_min_size = Vector2( 80, 80 )
+focus_neighbour_bottom = NodePath("../HBoxContainer3/Name")
+size_flags_horizontal = 0
+clip_text = true
+expand_icon = true
+
+[node name="HSeparator" type="HSeparator" parent="."]
+margin_top = 102.0
+margin_right = 1024.0
+margin_bottom = 106.0
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="."]
+margin_top = 110.0
+margin_right = 1024.0
+margin_bottom = 124.0
+
+[node name="Label" type="Label" parent="HBoxContainer2"]
+margin_right = 67.0
+margin_bottom = 14.0
+text = "Identifier: "
+
+[node name="Identifier" type="Label" parent="HBoxContainer2"]
+unique_name_in_owner = true
+margin_left = 71.0
+margin_right = 1024.0
+margin_bottom = 14.0
+size_flags_horizontal = 3
+autowrap = true
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="."]
+margin_top = 128.0
+margin_right = 1024.0
+margin_bottom = 152.0
+
+[node name="Label" type="Label" parent="HBoxContainer3"]
+margin_top = 5.0
+margin_right = 46.0
+margin_bottom = 19.0
+text = "Name: "
+
+[node name="Name" type="LineEdit" parent="HBoxContainer3"]
+unique_name_in_owner = true
+margin_left = 50.0
+margin_right = 1024.0
+margin_bottom = 24.0
+focus_neighbour_top = NodePath("../../Logo")
+size_flags_horizontal = 3
+placeholder_text = "Emulator name"
+caret_blink = true
+caret_blink_speed = 0.5
+
+[node name="HBoxContainer4" type="HBoxContainer" parent="."]
+margin_top = 156.0
+margin_right = 1024.0
+margin_bottom = 180.0
+
+[node name="Label" type="Label" parent="HBoxContainer4"]
+margin_top = 5.0
+margin_right = 36.0
+margin_bottom = 19.0
+text = "Path: "
+
+[node name="Path" type="LineEdit" parent="HBoxContainer4"]
+unique_name_in_owner = true
+margin_left = 40.0
+margin_right = 960.0
+margin_bottom = 24.0
+focus_neighbour_top = NodePath("../../Logo")
+size_flags_horizontal = 3
+placeholder_text = "Emulator executable path"
+caret_blink = true
+caret_blink_speed = 0.5
+
+[node name="LoadPath" type="Button" parent="HBoxContainer4"]
+margin_left = 964.0
+margin_right = 1024.0
+margin_bottom = 24.0
+text = "Load"
+icon = ExtResource( 2 )
+
+[node name="HBoxContainer5" type="HBoxContainer" parent="."]
+margin_top = 184.0
+margin_right = 1024.0
+margin_bottom = 208.0
+
+[node name="Label" type="Label" parent="HBoxContainer5"]
+margin_top = 5.0
+margin_right = 73.0
+margin_bottom = 19.0
+text = "Command: "
+
+[node name="Command" type="LineEdit" parent="HBoxContainer5"]
+unique_name_in_owner = true
+margin_left = 77.0
+margin_right = 1024.0
+margin_bottom = 24.0
+focus_neighbour_top = NodePath("../../Logo")
+size_flags_horizontal = 3
+placeholder_text = "Emulator command"
+caret_blink = true
+caret_blink_speed = 0.5
+
+[node name="HSeparator2" type="HSeparator" parent="."]
+margin_top = 212.0
+margin_right = 1024.0
+margin_bottom = 216.0
+
+[node name="Label2" type="Label" parent="."]
+margin_top = 220.0
+margin_right = 1024.0
+margin_bottom = 234.0
+text = "Available variables in command:"
+
+[node name="HFlowContainer" type="HFlowContainer" parent="."]
+margin_top = 238.0
+margin_right = 1024.0
+margin_bottom = 258.0
+custom_constants/hseparation = 15
+
+[node name="HBoxContainer" type="HBoxContainer" parent="HFlowContainer"]
+margin_right = 236.0
+margin_bottom = 20.0
+
+[node name="VarButton" type="Button" parent="HFlowContainer/HBoxContainer"]
+margin_right = 60.0
+margin_bottom = 20.0
+text = "binpath"
+
+[node name="Label" type="Label" parent="HFlowContainer/HBoxContainer"]
+margin_left = 64.0
+margin_top = 3.0
+margin_right = 236.0
+margin_bottom = 17.0
+text = "- Emulator executable path"
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="HFlowContainer"]
+margin_left = 251.0
+margin_right = 448.0
+margin_bottom = 20.0
+
+[node name="VarButton" type="Button" parent="HFlowContainer/HBoxContainer2"]
+margin_right = 66.0
+margin_bottom = 20.0
+text = "rompath"
+
+[node name="Label" type="Label" parent="HFlowContainer/HBoxContainer2"]
+margin_left = 70.0
+margin_top = 3.0
+margin_right = 197.0
+margin_bottom = 17.0
+text = "- Game file full path"
+
+[connection signal="text_changed" from="HBoxContainer3/Name" to="." method="_on_item_change"]
+[connection signal="text_changed" from="HBoxContainer4/Path" to="." method="_on_item_change"]
+[connection signal="pressed" from="HBoxContainer4/LoadPath" to="." method="_on_LoadPath_pressed"]
+[connection signal="text_changed" from="HBoxContainer5/Command" to="." method="_on_item_change"]
+[connection signal="pressed" from="HFlowContainer/HBoxContainer/VarButton" to="." method="_on_VarButton_pressed" binds= [ "{binpath}" ]]
+[connection signal="pressed" from="HFlowContainer/HBoxContainer2/VarButton" to="." method="_on_VarButton_pressed" binds= [ "{rompath}" ]]

--- a/source/Config.gd
+++ b/source/Config.gd
@@ -471,11 +471,13 @@ func save_system(system_raw: Dictionary):
 
 	# Find original config and modify it
 	var system_config : Array = JSONUtils.load_json_file(get_custom_systems_file())
+	var idx := 0
 	for child in system_config:
 		if child["name"] == system_raw["name"]:
-			child = system_raw
+			system_config[idx] = system_raw
 			JSONUtils.save_json_file(system_config, get_custom_systems_file())
 			return
+		idx += 1
 	# If not found, simply append info
 	system_config.push_back(system_raw)
 	JSONUtils.save_json_file(system_config, get_custom_systems_file())
@@ -491,6 +493,38 @@ func restore_system(system_raw: Dictionary):
 			var system_defaults : Array = JSONUtils.load_json_file(get_systems_file())
 			for default_child in system_defaults:
 				if default_child["name"] == system_raw["name"]:
+					return default_child
+
+func save_emulator(emulator_raw: Dictionary):
+	# Remove internal keys
+	emulator_raw.erase("#custom")
+	emulator_raw.erase("#modified")
+
+	# Find original config and modify it
+	var emulator_config : Array = JSONUtils.load_json_file(get_custom_emulators_file())
+	var idx := 0
+	for child in emulator_config:
+		if child["name"] == emulator_raw["name"]:
+			emulator_config[idx] = emulator_raw
+			JSONUtils.save_json_file(emulator_config, get_custom_emulators_file())
+			return
+		idx += 1
+	# If not found, simply append info
+	emulator_config.push_back(emulator_raw)
+	JSONUtils.save_json_file(emulator_config, get_custom_emulators_file())
+
+func restore_emulator(emulator_raw: Dictionary):
+	# Find original config and modify it
+	var emulator_config : Array = JSONUtils.load_json_file(get_custom_emulators_file())
+	for child in emulator_config:
+		if child["name"] == emulator_raw["name"]:
+			emulator_config.erase(child)
+			JSONUtils.save_json_file(emulator_config, get_custom_emulators_file())
+			# Now reload information
+			var system_defaults : Array = JSONUtils.load_json_file(get_emulators_file())
+			for default_child in system_defaults:
+				if default_child["name"] == emulator_raw["name"]:
+					JSONUtils.make_system_specific(default_child, FileUtils.get_os_string())
 					return default_child
 
 func get_config_dir() -> String:

--- a/source/emulators/GenericEmulator.gd
+++ b/source/emulators/GenericEmulator.gd
@@ -7,15 +7,17 @@ var _substitutes := {}
 
 func _init(emulator_raw : Dictionary, game_data : RetroHubGameData):
 	_substitutes["rompath"] = game_data.path
-	var binpath = find_and_substitute_str(emulator_raw["binpath"])
+	var binpath = find_and_substitute_str(emulator_raw["binpath"], _substitutes)
 	_substitutes["binpath"] = binpath
-	command = substitute_str(emulator_raw["command"])
+	command = substitute_str(emulator_raw["command"], _substitutes)
 
-func find_and_substitute_str(paths : Array) -> String:
-	return substitute_str(FileUtils.test_for_valid_path(paths))
+static func find_and_substitute_str(paths, substitutes: Dictionary) -> String:
+	if paths is Array:
+		return substitute_str(FileUtils.test_for_valid_path(paths), substitutes)
+	return substitute_str(paths, substitutes)
 
-func substitute_str(path) -> String:
-	return JSONUtils.format_string_with_substitutes(path, _substitutes)
+static func substitute_str(path, substitutes: Dictionary) -> String:
+	return JSONUtils.format_string_with_substitutes(path, substitutes)
 
 
 func launch_game():

--- a/source/emulators/RetroarchEmulator.gd
+++ b/source/emulators/RetroarchEmulator.gd
@@ -45,7 +45,7 @@ static func get_config_path() -> String:
 func _init(emulator_raw : Dictionary, game_data : RetroHubGameData, system_cores : Array).(emulator_raw, game_data):
 	var corepath := get_custom_core_path()
 	if corepath.empty():
-		corepath = find_and_substitute_str(emulator_raw["corepath"])
+		corepath = find_and_substitute_str(emulator_raw["corepath"], _substitutes)
 	var corefile : String
 	_substitutes["corepath"] = corepath
 	var dir = Directory.new()
@@ -61,6 +61,6 @@ func _init(emulator_raw : Dictionary, game_data : RetroHubGameData, system_cores
 			break
 	
 	if not corefile.empty():
-		command = substitute_str(command)
+		command = substitute_str(command, _substitutes)
 	else:
 		print("Could not find valid core file for emulator \"%s\"" % game_data.system.name)


### PR DESCRIPTION
Closes #84
![image](https://user-images.githubusercontent.com/6501975/215098159-db1bf655-9a6d-4231-941f-da55b2524d0b.png)
Allows basic modifications to existing emulators. RetroArch will need a different menu to handle modification of cores.