### PR TITLE
Implement graphic options and aspect ratios support

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -160,8 +160,9 @@ ControllerIcons="*res://addons/controller_icons/ControllerIcons.gd"
 
 [display]
 
+window/size/height=576
 window/stretch/mode="2d"
-window/stretch/aspect="keep"
+window/stretch/aspect="expand"
 
 [editor_plugins]
 

--- a/scenes/config/ConfigPopup.tscn
+++ b/scenes/config/ConfigPopup.tscn
@@ -18,14 +18,14 @@
 [ext_resource path="res://scenes/config/AboutSettings.tscn" type="PackedScene" id=16]
 
 [node name="ConfigPopup" type="PopupPanel"]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -435.2
-margin_top = -240.0
-margin_right = 435.2
-margin_bottom = 240.0
+anchor_left = 0.075
+anchor_top = 0.083
+anchor_right = 0.925
+anchor_bottom = 0.917
+margin_left = -1.52588e-05
+margin_top = 0.191998
+margin_right = -6.10352e-05
+margin_bottom = -0.192017
 theme = ExtResource( 1 )
 script = ExtResource( 6 )
 

--- a/scenes/config/settings/GeneralSettings.gd
+++ b/scenes/config/settings/GeneralSettings.gd
@@ -1,10 +1,16 @@
 extends Control
 
-onready var n_game_lib_dir = $"%GameLibDir"
-onready var n_set_game_path = $"%SetGamePath"
-onready var n_themes = $"%Themes"
-onready var n_language = $"%Language"
-onready var n_first_time_wizard_warning = $"%FirstTimeWizardWarning"
+onready var n_game_lib_dir := $"%GameLibDir"
+onready var n_set_game_path := $"%SetGamePath"
+onready var n_themes := $"%Themes"
+onready var n_language := $"%Language"
+onready var n_first_time_wizard_warning := $"%FirstTimeWizardWarning"
+
+onready var n_graphics_mode := $"%GraphicsMode"
+onready var n_vsync := $"%VSync"
+onready var n_render_res_label := $"%RenderResLabel"
+onready var n_render_res := $"%RenderRes"
+
 
 var theme_id_map := {}
 
@@ -57,6 +63,9 @@ func set_language(lang: String):
 
 func _on_config_ready(config_data: ConfigData):
 	n_game_lib_dir.text = config_data.games_dir
+	n_graphics_mode.selected = 1 if config_data.fullscreen else 0
+	n_vsync.pressed = config_data.vsync
+	n_render_res.value = config_data.render_resolution
 	set_language(config_data.lang)
 
 func _on_config_updated(key: String, _old_value, new_value):
@@ -103,3 +112,19 @@ func _on_FirstTimeWizardWarning_confirmed():
 
 func _on_SetupWizardButton_pressed():
 	n_first_time_wizard_warning.popup_centered()
+
+
+func _on_GraphicsMode_item_selected(index):
+	RetroHubConfig.config.fullscreen = index == 1
+	RetroHubConfig.save_config()
+
+
+func _on_VSync_toggled(button_pressed):
+	RetroHubConfig.config.vsync = button_pressed
+	RetroHubConfig.save_config()
+
+
+func _on_RenderRes_value_changed(value):
+	RetroHubConfig.config.render_resolution = value
+	n_render_res_label.text = str(value) + "%"
+

--- a/scenes/config/settings/GeneralSettings.tscn
+++ b/scenes/config/settings/GeneralSettings.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://scenes/config/settings/GeneralSettings.gd" type="Script" id=1]
+[ext_resource path="res://resources/fonts/default_bold.tres" type="DynamicFont" id=2]
 [ext_resource path="res://assets/icons/load.svg" type="Texture" id=3]
 
 [node name="GeneralSettings" type="Control"]
@@ -18,24 +19,40 @@ scroll_horizontal_enabled = false
 
 [node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer"]
 margin_right = 1024.0
-margin_bottom = 600.0
+margin_bottom = 576.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/VBoxContainer"]
+[node name="User" type="VBoxContainer" parent="ScrollContainer/VBoxContainer"]
 margin_right = 1024.0
-margin_bottom = 30.0
+margin_bottom = 154.0
+
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/User"]
+margin_right = 1024.0
+margin_bottom = 20.0
+custom_fonts/font = ExtResource( 2 )
+text = "User"
+
+[node name="HSeparator" type="HSeparator" parent="ScrollContainer/VBoxContainer/User"]
+margin_top = 24.0
+margin_right = 1024.0
+margin_bottom = 28.0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/User"]
+margin_top = 32.0
+margin_right = 1024.0
+margin_bottom = 62.0
 size_flags_horizontal = 3
 custom_constants/separation = 15
 
-[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/User/HBoxContainer"]
 margin_top = 8.0
 margin_right = 617.0
 margin_bottom = 22.0
 size_flags_horizontal = 3
 text = "Game library directory:"
 
-[node name="GameLibDir" type="LineEdit" parent="ScrollContainer/VBoxContainer/HBoxContainer"]
+[node name="GameLibDir" type="LineEdit" parent="ScrollContainer/VBoxContainer/User/HBoxContainer"]
 unique_name_in_owner = true
 margin_left = 632.0
 margin_right = 932.0
@@ -46,7 +63,7 @@ editable = false
 caret_blink = true
 caret_blink_speed = 0.5
 
-[node name="SetGamePath" type="Button" parent="ScrollContainer/VBoxContainer/HBoxContainer"]
+[node name="SetGamePath" type="Button" parent="ScrollContainer/VBoxContainer/User/HBoxContainer"]
 unique_name_in_owner = true
 margin_left = 947.0
 margin_right = 1024.0
@@ -54,28 +71,28 @@ margin_bottom = 30.0
 text = "Choose"
 icon = ExtResource( 3 )
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="ScrollContainer/VBoxContainer"]
-margin_top = 34.0
+[node name="HBoxContainer2" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/User"]
+margin_top = 66.0
 margin_right = 1024.0
-margin_bottom = 64.0
+margin_bottom = 96.0
 size_flags_horizontal = 3
 custom_constants/separation = 15
 
-[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/HBoxContainer2"]
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/User/HBoxContainer2"]
 margin_top = 8.0
 margin_right = 617.0
 margin_bottom = 22.0
 size_flags_horizontal = 3
 text = "Theme:"
 
-[node name="Themes" type="OptionButton" parent="ScrollContainer/VBoxContainer/HBoxContainer2"]
+[node name="Themes" type="OptionButton" parent="ScrollContainer/VBoxContainer/User/HBoxContainer2"]
 unique_name_in_owner = true
 margin_left = 632.0
 margin_right = 866.0
 margin_bottom = 30.0
 rect_min_size = Vector2( 234, 30 )
 
-[node name="SetThemePath" type="Button" parent="ScrollContainer/VBoxContainer/HBoxContainer2"]
+[node name="SetThemePath" type="Button" parent="ScrollContainer/VBoxContainer/User/HBoxContainer2"]
 unique_name_in_owner = true
 margin_left = 881.0
 margin_right = 1024.0
@@ -83,20 +100,20 @@ margin_bottom = 30.0
 text = "Open theme path"
 icon = ExtResource( 3 )
 
-[node name="HBoxContainer3" type="HBoxContainer" parent="ScrollContainer/VBoxContainer"]
-margin_top = 68.0
+[node name="HBoxContainer3" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/User"]
+margin_top = 100.0
 margin_right = 1024.0
-margin_bottom = 98.0
+margin_bottom = 130.0
 size_flags_horizontal = 3
 
-[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/HBoxContainer3"]
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/User/HBoxContainer3"]
 margin_top = 8.0
 margin_right = 720.0
 margin_bottom = 22.0
 size_flags_horizontal = 3
 text = "Language:"
 
-[node name="Language" type="OptionButton" parent="ScrollContainer/VBoxContainer/HBoxContainer3"]
+[node name="Language" type="OptionButton" parent="ScrollContainer/VBoxContainer/User/HBoxContainer3"]
 unique_name_in_owner = true
 margin_left = 724.0
 margin_right = 1024.0
@@ -106,14 +123,107 @@ text = "English (en)"
 items = [ "English (en)", null, false, 0, null ]
 selected = 0
 
-[node name="SetupWizardButton" type="Button" parent="ScrollContainer/VBoxContainer"]
+[node name="SetupWizardButton" type="Button" parent="ScrollContainer/VBoxContainer/User"]
 unique_name_in_owner = true
 margin_left = 862.0
-margin_top = 102.0
+margin_top = 134.0
 margin_right = 1024.0
-margin_bottom = 122.0
+margin_bottom = 154.0
 size_flags_horizontal = 8
 text = "Re-run first time wizard"
+
+[node name="Graphics" type="VBoxContainer" parent="ScrollContainer/VBoxContainer"]
+margin_top = 158.0
+margin_right = 1024.0
+margin_bottom = 274.0
+
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/Graphics"]
+margin_right = 1024.0
+margin_bottom = 20.0
+custom_fonts/font = ExtResource( 2 )
+text = "Graphics"
+
+[node name="HSeparator" type="HSeparator" parent="ScrollContainer/VBoxContainer/Graphics"]
+margin_top = 24.0
+margin_right = 1024.0
+margin_bottom = 28.0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/Graphics"]
+margin_top = 32.0
+margin_right = 1024.0
+margin_bottom = 52.0
+size_flags_horizontal = 3
+custom_constants/separation = 15
+
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/Graphics/HBoxContainer"]
+margin_top = 3.0
+margin_right = 913.0
+margin_bottom = 17.0
+size_flags_horizontal = 3
+text = "Mode:"
+
+[node name="GraphicsMode" type="OptionButton" parent="ScrollContainer/VBoxContainer/Graphics/HBoxContainer"]
+unique_name_in_owner = true
+margin_left = 928.0
+margin_right = 1024.0
+margin_bottom = 20.0
+text = "Windowed"
+items = [ "Windowed", null, false, 0, null, "Fullscreen", null, false, 1, null ]
+selected = 0
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/Graphics"]
+margin_top = 56.0
+margin_right = 1024.0
+margin_bottom = 96.0
+size_flags_horizontal = 3
+custom_constants/separation = 15
+
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/Graphics/HBoxContainer2"]
+margin_top = 13.0
+margin_right = 933.0
+margin_bottom = 27.0
+size_flags_horizontal = 3
+text = "Enable V-Sync:"
+
+[node name="VSync" type="CheckButton" parent="ScrollContainer/VBoxContainer/Graphics/HBoxContainer2"]
+unique_name_in_owner = true
+margin_left = 948.0
+margin_right = 1024.0
+margin_bottom = 40.0
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/Graphics"]
+margin_top = 100.0
+margin_right = 1024.0
+margin_bottom = 116.0
+size_flags_horizontal = 3
+custom_constants/separation = 15
+
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/Graphics/HBoxContainer3"]
+margin_top = 1.0
+margin_right = 758.0
+margin_bottom = 15.0
+size_flags_horizontal = 3
+text = "Render resolution:"
+
+[node name="RenderResLabel" type="Label" parent="ScrollContainer/VBoxContainer/Graphics/HBoxContainer3"]
+unique_name_in_owner = true
+margin_left = 773.0
+margin_top = 1.0
+margin_right = 809.0
+margin_bottom = 15.0
+text = "100%"
+
+[node name="RenderRes" type="HSlider" parent="ScrollContainer/VBoxContainer/Graphics/HBoxContainer3"]
+unique_name_in_owner = true
+margin_left = 824.0
+margin_right = 1024.0
+margin_bottom = 16.0
+rect_min_size = Vector2( 200, 0 )
+min_value = 50.0
+step = 5.0
+value = 100.0
+tick_count = 11
+ticks_on_borders = true
 
 [node name="FirstTimeWizardWarning" type="ConfirmationDialog" parent="."]
 unique_name_in_owner = true
@@ -146,9 +256,13 @@ autowrap = true
 
 [connection signal="hide" from="." to="." method="_on_AppSettings_hide"]
 [connection signal="visibility_changed" from="." to="." method="_on_AppSettings_visibility_changed"]
-[connection signal="pressed" from="ScrollContainer/VBoxContainer/HBoxContainer/SetGamePath" to="." method="_on_SetGamePath_pressed"]
-[connection signal="item_selected" from="ScrollContainer/VBoxContainer/HBoxContainer2/Themes" to="." method="_on_Themes_item_selected"]
-[connection signal="pressed" from="ScrollContainer/VBoxContainer/HBoxContainer2/SetThemePath" to="." method="_on_SetThemePath_pressed"]
-[connection signal="item_selected" from="ScrollContainer/VBoxContainer/HBoxContainer3/Language" to="." method="_on_Language_item_selected"]
-[connection signal="pressed" from="ScrollContainer/VBoxContainer/SetupWizardButton" to="." method="_on_SetupWizardButton_pressed"]
+[connection signal="pressed" from="ScrollContainer/VBoxContainer/User/HBoxContainer/SetGamePath" to="." method="_on_SetGamePath_pressed"]
+[connection signal="item_selected" from="ScrollContainer/VBoxContainer/User/HBoxContainer2/Themes" to="." method="_on_Themes_item_selected"]
+[connection signal="pressed" from="ScrollContainer/VBoxContainer/User/HBoxContainer2/SetThemePath" to="." method="_on_SetThemePath_pressed"]
+[connection signal="item_selected" from="ScrollContainer/VBoxContainer/User/HBoxContainer3/Language" to="." method="_on_Language_item_selected"]
+[connection signal="pressed" from="ScrollContainer/VBoxContainer/User/SetupWizardButton" to="." method="_on_SetupWizardButton_pressed"]
+[connection signal="item_selected" from="ScrollContainer/VBoxContainer/Graphics/HBoxContainer/GraphicsMode" to="." method="_on_GraphicsMode_item_selected"]
+[connection signal="toggled" from="ScrollContainer/VBoxContainer/Graphics/HBoxContainer2/VSync" to="." method="_on_VSync_toggled"]
+[connection signal="drag_ended" from="ScrollContainer/VBoxContainer/Graphics/HBoxContainer3/RenderRes" to="." method="_on_RenderRes_drag_ended"]
+[connection signal="value_changed" from="ScrollContainer/VBoxContainer/Graphics/HBoxContainer3/RenderRes" to="." method="_on_RenderRes_value_changed"]
 [connection signal="confirmed" from="FirstTimeWizardWarning" to="." method="_on_FirstTimeWizardWarning_confirmed"]

--- a/scenes/root/Root.tscn
+++ b/scenes/root/Root.tscn
@@ -32,7 +32,8 @@ anchor_bottom = 1.0
 stretch = true
 
 [node name="Viewport" type="Viewport" parent="ViewportContainer"]
-size = Vector2( 1024, 600 )
+size = Vector2( 1024, 576 )
+size_override_stretch = true
 handle_input_locally = false
 render_target_update_mode = 3
 script = ExtResource( 4 )

--- a/source/data/ConfigData.gd
+++ b/source/data/ConfigData.gd
@@ -11,6 +11,9 @@ var is_first_time : bool = true setget _set_is_first_time
 var games_dir : String = FileUtils.get_home_dir() + "/ROMS" setget _set_games_dir
 var current_theme : String = "default" setget _set_current_theme
 var lang : String = "en" setget _set_lang
+var fullscreen : bool = true setget _set_fullscreen
+var vsync : bool = true setget _set_vsync
+var render_resolution : int = 100 setget _set_render_resolution
 var region : String = "usa" setget _set_region
 var rating_system : String = "esrb" setget _set_rating_system
 var date_format : String = "mm/dd/yyyy" setget _set_date_format
@@ -28,6 +31,9 @@ const KEY_IS_FIRST_TIME = "is_first_time"
 const KEY_GAMES_DIR = "games_dir"
 const KEY_CURRENT_THEME = "current_theme"
 const KEY_LANG = "lang"
+const KEY_FULLSCREEN = "fullscreen"
+const KEY_VSYNC = "vsync"
+const KEY_RENDER_RESOLUTION = "render_resolution"
 const KEY_REGION = "region"
 const KEY_RATING_SYSTEM = "rating_system"
 const KEY_DATE_FORMAT = "date_format"
@@ -46,6 +52,9 @@ const _keys = [
 	KEY_GAMES_DIR,
 	KEY_CURRENT_THEME,
 	KEY_LANG,
+	KEY_FULLSCREEN,
+	KEY_VSYNC,
+	KEY_RENDER_RESOLUTION,
 	KEY_REGION,
 	KEY_RATING_SYSTEM,
 	KEY_DATE_FORMAT,
@@ -114,6 +123,18 @@ func _set_current_theme(_current_theme):
 func _set_lang(_lang):
 	mark_for_saving()
 	lang = _lang
+
+func _set_fullscreen(_fullscreen):
+	mark_for_saving()
+	fullscreen = _fullscreen
+
+func _set_vsync(_vsync):
+	mark_for_saving()
+	vsync = _vsync
+
+func _set_render_resolution(_render_resolution):
+	mark_for_saving()
+	render_resolution = _render_resolution
 
 func _set_region(_region):
 	mark_for_saving()


### PR DESCRIPTION
- Multiple aspect ratios are now supported. Themes should be developed for 16:9 resolutions, and support other ratios such as 21:9 or 4:3.
- New graphic options: windowed/fullscreen, theme render resolution and vsync (resolutions aren't applicable as Godot apparently doesn't set games to arbitrary resolutions)

Closes #30 