### PR TITLE
Fix various ScreenScraper issues

### DIFF
--- a/scenes/config/ScreenScrapperSettings.tscn
+++ b/scenes/config/ScreenScrapperSettings.tscn
@@ -143,6 +143,8 @@ custom_fonts/normal_font = SubResource( 4 )
 bbcode_enabled = true
 bbcode_text = "[img=20]assets/icons/warning.svg[/img][i][b] Warning: [/b]Due to the way ScreenScraper works, the password will be stored in plaintext.[/i]"
 text = " Warning: Due to the way ScreenScraper works, the password will be stored in plaintext."
+fit_content_height = true
+scroll_active = false
 
 [connection signal="toggled" from="HBoxContainer/UseAccount" to="." method="_on_UseAccount_toggled"]
 [connection signal="text_changed" from="HBoxContainer2/Username" to="." method="_on_Username_text_changed"]

--- a/scenes/popups/scraper/Error.gd
+++ b/scenes/popups/scraper/Error.gd
@@ -1,16 +1,17 @@
 extends Control
 
-signal retry_entry(game_entry)
+signal retry_entry(game_entry, req)
 
 onready var n_label = $"%ErrorLabel"
 onready var base_text = n_label.text
 
 var game_entry
+var req
 
 func set_entry(_game_entry: RetroHubScraperGameEntry):
 	game_entry = _game_entry
-	n_label.text = base_text % [game_entry.game_data.path.get_file(), game_entry.data]
-
+	n_label.text = base_text % [game_entry.game_data.path.get_file(), game_entry.data[0]]
+	req = game_entry.data[1]
 
 func _on_ErrorRetryButton_pressed():
-	emit_signal("retry_entry", game_entry)
+	emit_signal("retry_entry", game_entry, req)

--- a/scenes/popups/scraper/ScraperPopup.tscn
+++ b/scenes/popups/scraper/ScraperPopup.tscn
@@ -53,32 +53,32 @@ margin_bottom = 22.0
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 margin_top = 26.0
 margin_right = 1016.0
-margin_bottom = 560.0
+margin_bottom = 536.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HBoxContainer"]
 margin_right = 400.0
-margin_bottom = 534.0
+margin_bottom = 510.0
 rect_min_size = Vector2( 400, 0 )
 
 [node name="GameEntries" type="VBoxContainer" parent="VBoxContainer/HBoxContainer/ScrollContainer"]
 unique_name_in_owner = true
 margin_right = 400.0
-margin_bottom = 534.0
+margin_bottom = 510.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/HBoxContainer"]
 margin_left = 404.0
 margin_right = 408.0
-margin_bottom = 534.0
+margin_bottom = 510.0
 
 [node name="GameEntryEditor" type="TabContainer" parent="VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 margin_left = 412.0
 margin_right = 1016.0
-margin_bottom = 534.0
+margin_bottom = 510.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 tabs_visible = false
@@ -109,7 +109,7 @@ margin_bottom = 22.0
 [node name="Root" type="Control" parent="VBoxContainer/HBoxContainer/GameEntryEditor/Success/VBoxContainer"]
 margin_top = 26.0
 margin_right = 596.0
-margin_bottom = 522.0
+margin_bottom = 498.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -164,9 +164,9 @@ step = 1.0
 
 [node name="WorkingCancelButton" type="Button" parent="VBoxContainer/HBoxContainer/GameEntryEditor/Working/VBoxContainer"]
 margin_left = 271.0
-margin_top = 196.0
+margin_top = 172.0
 margin_right = 325.0
-margin_bottom = 216.0
+margin_bottom = 192.0
 size_flags_horizontal = 4
 text = "Cancel"
 
@@ -189,9 +189,9 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Waiting" type="Label" parent="VBoxContainer/HBoxContainer/GameEntryEditor/Waiting/VBoxContainer"]
-margin_top = 86.0
+margin_top = 74.0
 margin_right = 596.0
-margin_bottom = 106.0
+margin_bottom = 94.0
 size_flags_horizontal = 3
 size_flags_vertical = 6
 custom_fonts/font = ExtResource( 6 )
@@ -202,9 +202,9 @@ autowrap = true
 
 [node name="WaitingCancelButton" type="Button" parent="VBoxContainer/HBoxContainer/GameEntryEditor/Waiting/VBoxContainer"]
 margin_left = 271.0
-margin_top = 196.0
+margin_top = 172.0
 margin_right = 325.0
-margin_bottom = 216.0
+margin_bottom = 192.0
 size_flags_horizontal = 4
 text = "Cancel"
 
@@ -252,13 +252,13 @@ text = "Search"
 [node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/HBoxContainer/GameEntryEditor/Warning/VBoxContainer"]
 margin_top = 63.0
 margin_right = 596.0
-margin_bottom = 522.0
+margin_bottom = 498.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HBoxContainer/GameEntryEditor/Warning/VBoxContainer/HBoxContainer2"]
 margin_right = 384.0
-margin_bottom = 459.0
+margin_bottom = 435.0
 size_flags_horizontal = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer/GameEntryEditor/Warning/VBoxContainer/HBoxContainer2/ScrollContainer"]
@@ -359,36 +359,36 @@ autowrap = true
 [node name="HSeparator" type="VSeparator" parent="VBoxContainer/HBoxContainer/GameEntryEditor/Warning/VBoxContainer/HBoxContainer2"]
 margin_left = 388.0
 margin_right = 392.0
-margin_bottom = 459.0
+margin_bottom = 435.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer/GameEntryEditor/Warning/VBoxContainer/HBoxContainer2"]
 margin_left = 396.0
 margin_right = 596.0
-margin_bottom = 459.0
+margin_bottom = 435.0
 
 [node name="ScrollContainer2" type="ScrollContainer" parent="VBoxContainer/HBoxContainer/GameEntryEditor/Warning/VBoxContainer/HBoxContainer2/VBoxContainer"]
 margin_right = 200.0
-margin_bottom = 427.0
+margin_bottom = 403.0
 rect_min_size = Vector2( 200, 0 )
 size_flags_vertical = 3
 
 [node name="GameSearchEntries" type="VBoxContainer" parent="VBoxContainer/HBoxContainer/GameEntryEditor/Warning/VBoxContainer/HBoxContainer2/VBoxContainer/ScrollContainer2"]
 unique_name_in_owner = true
 margin_right = 200.0
-margin_bottom = 427.0
+margin_bottom = 403.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer/HBoxContainer/GameEntryEditor/Warning/VBoxContainer/HBoxContainer2/VBoxContainer"]
-margin_top = 431.0
+margin_top = 407.0
 margin_right = 200.0
-margin_bottom = 435.0
+margin_bottom = 411.0
 
 [node name="Confirm" type="Button" parent="VBoxContainer/HBoxContainer/GameEntryEditor/Warning/VBoxContainer/HBoxContainer2/VBoxContainer"]
 unique_name_in_owner = true
-margin_top = 439.0
+margin_top = 415.0
 margin_right = 200.0
-margin_bottom = 459.0
+margin_bottom = 435.0
 disabled = true
 text = "Confirm"
 
@@ -438,14 +438,14 @@ size_flags_vertical = 0
 text = "Retry"
 
 [node name="HSeparator2" type="HSeparator" parent="VBoxContainer"]
-margin_top = 564.0
+margin_top = 540.0
 margin_right = 1016.0
-margin_bottom = 568.0
+margin_bottom = 544.0
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 572.0
+margin_top = 548.0
 margin_right = 1016.0
-margin_bottom = 592.0
+margin_bottom = 568.0
 custom_constants/separation = 10
 
 [node name="PendingGames" type="Label" parent="VBoxContainer/HBoxContainer2"]
@@ -470,9 +470,9 @@ anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 margin_left = -508.0
-margin_top = -296.0
+margin_top = -284.0
 margin_right = 508.0
-margin_bottom = 296.0
+margin_bottom = 284.0
 script = ExtResource( 10 )
 
 [node name="StopDescription" type="Label" parent="StopScraperDialog"]

--- a/source/data/GameData.gd
+++ b/source/data/GameData.gd
@@ -7,25 +7,28 @@ static func sort(a: RetroHubGameData, b: RetroHubGameData):
 
 func duplicate(_subresources: bool = false) -> Resource:
 	var other = .duplicate(_subresources)
-
-	other.has_metadata = has_metadata
-	other.has_media = has_media
-	other.system = system
-	other.name = name
-	other.path = path
-	other.description = description
-	other.rating = rating
-	other.release_date = release_date
-	other.developer = developer
-	other.publisher = publisher
-	other.genres = genres.duplicate()
-	other.num_players = num_players
-	other.age_rating = age_rating
-	other.favorite = favorite
-	other.play_count = play_count
-	other.last_played = last_played
+	other.copy_from(self)
 
 	return other
+
+func copy_from(other: RetroHubGameData) -> void:
+	has_metadata = other.has_metadata
+	has_media = other.has_media
+	system = other.system
+	system_path = other.system_path
+	name = other.name
+	path = other.path
+	description = other.description
+	rating = other.rating
+	release_date = other.release_date
+	developer = other.developer
+	publisher = other.publisher
+	genres = other.genres.duplicate()
+	num_players = other.num_players
+	age_rating = other.age_rating
+	favorite = other.favorite
+	play_count = other.play_count
+	last_played = other.last_played
 
 ## Whether this game already has metadata; if it doesn't, you should
 ## present a much simpler view of it

--- a/source/scraper/Scraper.gd
+++ b/source/scraper/Scraper.gd
@@ -2,26 +2,26 @@ extends Node
 class_name RetroHubScraper
 
 # Signals that a game scrape has finished successfully, returning the
-# altered game data
+# modified game data.
 signal game_scrape_finished(game_data)
 # Signals that a game scrape is incomplete since there are multiple
 # possible results. Returns the list of game datas of all results.
-# A further scrape must be done under one of these datas to uniquely
-# identify it and finish the scraping process properly
+# A further scrape will be called under one of these datas to uniquely
+# identify it and finish the scraping process properly.
 signal game_scrape_multiple_available(game_data, results)
 # Signals that a game scrape has failed because no results were found.
 signal game_scrape_not_found(game_data)
 # Signals that a game scrape resulted in an error, returning further
-# details to show to the user
+# details to show to the user.
 signal game_scrape_error(game_data, details)
 
 # Signals that a media scrape has completed, returning it's
-# type (from RetroHubMedia), raw content and file extension
+# type (from RetroHubMedia), raw content and file extension.
 signal media_scrape_finished(game_data, type, data, extension)
 # Signals that a media scrape has failed because no results were found.
 signal media_scrape_not_found(game_data, type)
 # Signals that a media scrape resulted in an error, returning further
-# details to show to the user
+# details to show to the user.
 signal media_scrape_error(game_data, type, details)
 
 
@@ -36,43 +36,59 @@ signal media_scrape_error(game_data, type, details)
 ## doesn't do busy waits.
 
 # Start a metadata scrape by the game file's hash.
-# This allows a scrape to be unique regardless
-# of the game's local filenames. If the game
-# cannot be uniquely identified by this
-# method, this should signal "game_scrape_not_found"
+# This allows a scrape to be uniquely identified regardless of the
+# game filenames. If the game cannot be uniquely identified by this
+# method, this should signal "game_scrape_not_found". RetroHub may
+# then try doing a scrape by search if configured to do so.
 func scrape_game_by_hash(game_data: RetroHubGameData) -> int:
 	return -1
 
-# Start a metadata scrape by searching with a given search them.
-# This allows possibly multiple scrape results, in
-# which case this function must signal "game_scrape_multiple_available", and
-# "game_scrape_not_found" if there are no results.
+# Start a metadata scrape by searching by the supplied search term.
+# This may result in multiple scrape results, in which case this
+# function must signal `game_scrape_multiple_available`. If no results
+# are found, it should signal "game_scrape_not_found".
 func scrape_game_by_search(game_data: RetroHubGameData, search_term: String) -> int:
 	return -1
 
 # Start a media scrape for a specific media type. This will
-# download a media file and return it's raw content. The main app
+# download a media file and must return it's raw content. The main app
 # will always call this ONLY after a successfull game data scrape.
-# media_type should be a value from RetroHubMedia.Type enum.
-# This function can fail immediately, in which case the main app will "skip" this
-# media file.
+# `media_type` is a value from the RetroHubMedia.Type enum.
+# `game_data` may be either an original existing game data or one of the
+# temporary datas returned in the `game_scrape_multiple_available` signal.
+# This function can fail immediately, in which case the main app will
+# skip this media file.
 func scrape_media(game_data: RetroHubGameData, media_type: int) -> int:
 	return -1
 
-# Marks a given game data as fully scraped. The app won't require any more
-# information from it, so any data associated with it can be freed by
-# the scraper. If the app eventually needs to rescrape it for some reason
-# it will restart the whole process of scraping without prior assumptions
+# Start a media scrape for a specific media type. This will
+# download a media file and return it's raw content. The main app
+# will call this function instead of the `scrape_media` if this data was
+# manually picked by the user from search results, where `orig_game_data`
+# is the original file to modify, and `search_game_data` the temporary data
+# this scraper returned on the `game_scrape_multiple_available` signal.
+# `media_type` is a value from the RetroHubMedia.Type enum.
+# This function can fail immediately, in which case the main app will
+# skip thimedia file.
+func scrape_media_from_search(orig_game_data: RetroHubGameData, search_game_data: RetroHubGameData, media_type: int) -> int:
+	return -1
+
+# Marks a given game data as fully scraped, meaning RetroHub won't require any more
+# information from it, and so any data associated with it can be freed by
+# the scraper. If the app needs to rescrape it for some reason, it will
+# restart the scraping process of without prior assumptions
 func scrape_completed(game_data: RetroHubGameData) -> void:
 	return
 
 # Cancels a pending request associated with a game data. This function
 # must return immediately. A given request might still finish even
-# after cancelation depending on it's state, in which case it will
-# be ignored by the app but may still be cached by the scraper.
+# after cancelation depending on it's state, but will be ignored by
+# RetroHub.
 func cancel(game_data: RetroHubGameData) -> void:
 	return
 
 # Cancels all pending requests. This function must return immediately.
+# Some requests might still finish even after cancelation depending on
+# it's state, but will be ignored by RetroHub.
 func cancel_all() -> void:
 	return


### PR DESCRIPTION
Some issues were fixed concerning the scraper:
- ScreenScraper password warning label was being "cut" of.
- "Hang" with games where hash checks fail and fallback to search.
- Retrying error scenarios was not considering request type (hash, search, media)
- Scraping game from search wouldn't update existing game data until app was restarted

Closes #55