### PR TITLE
Implement lazy loading of static assets

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -49,6 +49,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://source/importers/EmulationStationImporter.gd"
 }, {
+"base": "TextureRect",
+"class": "LazyTextureRect",
+"language": "GDScript",
+"path": "res://scenes/ui_nodes/LazyTextureRect.gd"
+}, {
 "base": "RetroHubImporter",
 "class": "RetroArchImporter",
 "language": "GDScript",
@@ -123,6 +128,7 @@ _global_script_class_icons={
 "ControllerSprite3D": "",
 "ControllerTextureRect": "",
 "EmulationStationImporter": "",
+"LazyTextureRect": "",
 "RetroArchImporter": "",
 "RetroHubGameData": "",
 "RetroHubGameMediaData": "",

--- a/scenes/config/AboutSettings.tscn
+++ b/scenes/config/AboutSettings.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://assets/icons/app/retrohub_logo_1024px_draft.png" type="Texture" id=1]
 [ext_resource path="res://resources/fonts/default_big.tres" type="DynamicFont" id=2]
@@ -9,6 +9,7 @@
 [ext_resource path="res://assets/copyright/controller_icons.png" type="Texture" id=7]
 [ext_resource path="res://scenes/config/Licenses.gd" type="Script" id=8]
 [ext_resource path="res://resources/fonts/default_italic.tres" type="DynamicFont" id=9]
+[ext_resource path="res://scenes/ui_nodes/LazyTextureRect.gd" type="Script" id=10]
 
 [node name="AboutSettings" type="Control"]
 anchor_right = 1.0
@@ -34,7 +35,7 @@ size_flags_vertical = 3
 follow_focus = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/About"]
-margin_right = 505.0
+margin_right = 1004.0
 margin_bottom = 634.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -49,6 +50,7 @@ margin_bottom = 128.0
 rect_min_size = Vector2( 128, 128 )
 texture = ExtResource( 1 )
 expand = true
+script = ExtResource( 10 )
 
 [node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/About/VBoxContainer/HBoxContainer"]
 margin_left = 132.0
@@ -136,6 +138,7 @@ size_flags_vertical = 3
 texture = ExtResource( 4 )
 expand = true
 stretch_mode = 5
+script = ExtResource( 10 )
 
 [node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/About/VBoxContainer/Godot/HBoxContainer"]
 margin_left = 80.0
@@ -188,6 +191,7 @@ size_flags_vertical = 3
 texture = ExtResource( 6 )
 expand = true
 stretch_mode = 5
+script = ExtResource( 10 )
 
 [node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/About/VBoxContainer/FFMPEG/HBoxContainer"]
 margin_left = 80.0
@@ -239,6 +243,7 @@ rect_min_size = Vector2( 76, 76 )
 size_flags_vertical = 3
 expand = true
 stretch_mode = 5
+script = ExtResource( 10 )
 
 [node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/About/VBoxContainer/godot-videodecoder/HBoxContainer"]
 margin_left = 80.0
@@ -294,6 +299,7 @@ size_flags_vertical = 3
 texture = ExtResource( 7 )
 expand = true
 stretch_mode = 5
+script = ExtResource( 10 )
 
 [node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/About/VBoxContainer/ControllerIcons/HBoxContainer"]
 margin_left = 80.0

--- a/scenes/config/ConfigPopup.tscn
+++ b/scenes/config/ConfigPopup.tscn
@@ -20,6 +20,7 @@
 [sub_resource type="ButtonGroup" id=1]
 
 [node name="ConfigPopup" type="Popup"]
+visible = true
 anchor_left = 0.075
 anchor_top = 0.083
 anchor_right = 0.925

--- a/scenes/config/settings/RegionSettings.gd
+++ b/scenes/config/settings/RegionSettings.gd
@@ -63,12 +63,12 @@ func set_system_names(system_names: Dictionary):
 	n_tg_16.selected = 0 if system_names["tg16"] == "tg16" else 1
 	n_tg_cd.selected = 0 if system_names["tg-cd"] == "tg-cd" else 1
 	n_odyssey2.selected = 0 if system_names["odyssey2"] == "odyssey2" else 1
-	n_genesis_icon.texture = load("res://assets/systems/%s-photo.png" % system_names["genesis"])
-	n_nes_icon.texture = load("res://assets/systems/%s-photo.png" % system_names["nes"])
-	n_snes_icon.texture = load("res://assets/systems/%s-photo.png" % system_names["snes"])
-	n_tg_16_icon.texture = load("res://assets/systems/%s-photo.png" % system_names["tg16"])
-	n_tgcd_icon.texture = load("res://assets/systems/%s-photo.png" % system_names["tg-cd"])
-	n_odyssey2_icon.texture = load("res://assets/systems/%s-photo.png" % system_names["odyssey2"])
+	n_genesis_icon.set_texture(load("res://assets/systems/%s-photo.png" % system_names["genesis"]))
+	n_nes_icon.set_texture(load("res://assets/systems/%s-photo.png" % system_names["nes"]))
+	n_snes_icon.set_texture(load("res://assets/systems/%s-photo.png" % system_names["snes"]))
+	n_tg_16_icon.set_texture(load("res://assets/systems/%s-photo.png" % system_names["tg16"]))
+	n_tgcd_icon.set_texture(load("res://assets/systems/%s-photo.png" % system_names["tg-cd"]))
+	n_odyssey2_icon.set_texture(load("res://assets/systems/%s-photo.png" % system_names["odyssey2"]))
 
 func _on_config_ready(config_data: ConfigData):
 	set_region(config_data.region)
@@ -139,35 +139,35 @@ func _on_ResetRegion_pressed():
 
 func _on_Genesis_item_selected(index):
 	RetroHubConfig.config.system_names["genesis"] = "megadrive" if index == 1 else "genesis"
-	n_genesis_icon.texture = load("res://assets/systems/%s-photo.png" % RetroHubConfig.config.system_names["genesis"])
+	n_genesis_icon.set_texture(load("res://assets/systems/%s-photo.png" % RetroHubConfig.config.system_names["genesis"]))
 	emit_signal("theme_reload")
 
 
 func _on_NES_item_selected(index):
 	RetroHubConfig.config.system_names["nes"] = "famicom" if index == 1 else "nes"
-	n_nes_icon.texture = load("res://assets/systems/%s-photo.png" % RetroHubConfig.config.system_names["nes"])
+	n_nes_icon.set_texture(load("res://assets/systems/%s-photo.png" % RetroHubConfig.config.system_names["nes"]))
 	emit_signal("theme_reload")
 
 
 func _on_SNES_item_selected(index):
 	RetroHubConfig.config.system_names["snes"] = "sfc" if index == 1 else "snes"
-	n_snes_icon.texture = load("res://assets/systems/%s-photo.png" % RetroHubConfig.config.system_names["snes"])
+	n_snes_icon.set_texture(load("res://assets/systems/%s-photo.png" % RetroHubConfig.config.system_names["snes"]))
 	emit_signal("theme_reload")
 
 
 func _on_TG16_item_selected(index):
 	RetroHubConfig.config.system_names["tg16"] = "pcengine" if index == 1 else "tg16"
-	n_tg_16_icon.texture = load("res://assets/systems/%s-photo.png" % RetroHubConfig.config.system_names["tg16"])
+	n_tg_16_icon.set_texture(load("res://assets/systems/%s-photo.png" % RetroHubConfig.config.system_names["tg16"]))
 	emit_signal("theme_reload")
 
 
 func _on_TGCD_item_selected(index):
 	RetroHubConfig.config.system_names["tg-cd"] = "pcenginecd" if index == 1 else "tg-cd"
-	n_tgcd_icon.texture = load("res://assets/systems/%s-photo.png" % RetroHubConfig.config.system_names["tg-cd"])
+	n_tgcd_icon.set_texture(load("res://assets/systems/%s-photo.png" % RetroHubConfig.config.system_names["tg-cd"]))
 	emit_signal("theme_reload")
 
 
 func _on_Odyssey2_item_selected(index):
 	RetroHubConfig.config.system_names["odyssey2"] = "videopac" if index == 1 else "odyssey2"
-	n_odyssey2_icon.texture = load("res://assets/systems/%s-photo.png" % RetroHubConfig.config.system_names["odyssey2"])
+	n_odyssey2_icon.set_texture(load("res://assets/systems/%s-photo.png" % RetroHubConfig.config.system_names["odyssey2"]))
 	emit_signal("theme_reload")

--- a/scenes/config/settings/RegionSettings.tscn
+++ b/scenes/config/settings/RegionSettings.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://scenes/config/settings/RegionSettings.gd" type="Script" id=1]
 [ext_resource path="res://assets/ratings/esrb/E.png" type="Texture" id=2]
 [ext_resource path="res://assets/systems/nes-photo.png" type="Texture" id=3]
 [ext_resource path="res://assets/ratings/pegi/3.png" type="Texture" id=4]
 [ext_resource path="res://assets/ratings/cero/A.png" type="Texture" id=5]
+[ext_resource path="res://scenes/ui_nodes/LazyTextureRect.gd" type="Script" id=6]
 [ext_resource path="res://assets/systems/tg16-photo.png" type="Texture" id=7]
 [ext_resource path="res://assets/systems/tg-cd-photo.png" type="Texture" id=8]
 [ext_resource path="res://assets/systems/snes-photo.png" type="Texture" id=9]
@@ -150,6 +151,7 @@ rect_min_size = Vector2( 100, 100 )
 texture = ExtResource( 11 )
 expand = true
 stretch_mode = 6
+script = ExtResource( 6 )
 
 [node name="HBoxContainer2" type="VBoxContainer" parent="ScrollContainer/VBoxContainer/SystemsContainer"]
 margin_left = 154.0
@@ -176,6 +178,7 @@ rect_min_size = Vector2( 100, 100 )
 texture = ExtResource( 3 )
 expand = true
 stretch_mode = 6
+script = ExtResource( 6 )
 
 [node name="HBoxContainer3" type="VBoxContainer" parent="ScrollContainer/VBoxContainer/SystemsContainer"]
 margin_left = 308.0
@@ -202,6 +205,7 @@ rect_min_size = Vector2( 100, 100 )
 texture = ExtResource( 9 )
 expand = true
 stretch_mode = 6
+script = ExtResource( 6 )
 
 [node name="HBoxContainer4" type="VBoxContainer" parent="ScrollContainer/VBoxContainer/SystemsContainer"]
 margin_left = 462.0
@@ -228,6 +232,7 @@ rect_min_size = Vector2( 100, 100 )
 texture = ExtResource( 7 )
 expand = true
 stretch_mode = 6
+script = ExtResource( 6 )
 
 [node name="HBoxContainer5" type="VBoxContainer" parent="ScrollContainer/VBoxContainer/SystemsContainer"]
 margin_left = 616.0
@@ -255,6 +260,7 @@ rect_min_size = Vector2( 100, 100 )
 texture = ExtResource( 8 )
 expand = true
 stretch_mode = 6
+script = ExtResource( 6 )
 
 [node name="HBoxContainer6" type="VBoxContainer" parent="ScrollContainer/VBoxContainer/SystemsContainer"]
 margin_left = 770.0
@@ -281,6 +287,7 @@ rect_min_size = Vector2( 100, 100 )
 texture = ExtResource( 10 )
 expand = true
 stretch_mode = 6
+script = ExtResource( 6 )
 
 [connection signal="hide" from="." to="." method="_on_AppSettings_hide"]
 [connection signal="visibility_changed" from="." to="." method="_on_AppSettings_visibility_changed"]

--- a/scenes/config/settings/input/ControllerLayout.gd
+++ b/scenes/config/settings/input/ControllerLayout.gd
@@ -3,7 +3,6 @@ extends WindowDialog
 export(Color) var unknown_mapping : Color
 export(Color) var current_mapping : Color
 export(Color) var known_mapping : Color
-export(String, FILE, "*.png") var diagram_tex : String
 
 # Code adapted from Godot "Joypads Demo / Tool"
 # https://godotengine.org/asset-library/asset/140
@@ -255,7 +254,6 @@ func start():
 	joy_guid = Input.get_joy_guid(0)
 	joy_name = Input.get_joy_name(0)
 	Input.remove_joy_mapping(joy_guid)
-	n_diagram.texture = load(diagram_tex)
 	curr_step = 0
 	step()
 

--- a/scenes/config/settings/input/ControllerLayout.tscn
+++ b/scenes/config/settings/input/ControllerLayout.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://scenes/config/settings/input/ControllerLayout.gd" type="Script" id=1]
+[ext_resource path="res://addons/controller_icons/assets/xboxone/diagram_simple.png" type="Texture" id=2]
+[ext_resource path="res://scenes/ui_nodes/LazyTextureRect.gd" type="Script" id=3]
 [ext_resource path="res://assets/icons/controller_mapper/circle.png" type="Texture" id=4]
 [ext_resource path="res://assets/icons/controller_mapper/arrow.png" type="Texture" id=5]
 [ext_resource path="res://assets/icons/controller_mapper/circle_progress.png" type="Texture" id=6]
@@ -22,7 +24,6 @@ script = ExtResource( 1 )
 unknown_mapping = Color( 0.0901961, 0.0901961, 0.0901961, 0.737255 )
 current_mapping = Color( 0.360784, 0.839216, 0, 0.717647 )
 known_mapping = Color( 0.133333, 0.313726, 0, 0.737255 )
-diagram_tex = "res://addons/controller_icons/assets/xboxone/diagram_simple.png"
 
 [node name="TopLabelRoot" type="Control" parent="."]
 anchor_right = 1.0
@@ -81,7 +82,9 @@ margin_top = -172.5
 margin_right = 252.0
 margin_bottom = 146.5
 rect_min_size = Vector2( 40, 25 )
+texture = ExtResource( 2 )
 expand = true
+script = ExtResource( 3 )
 __meta__ = {
 "_edit_group_": true
 }

--- a/scenes/ui_nodes/LazyTextureRect.gd
+++ b/scenes/ui_nodes/LazyTextureRect.gd
@@ -1,0 +1,26 @@
+extends TextureRect
+class_name LazyTextureRect
+
+var resource_path = null
+
+func _ready():
+	if texture:
+		resource_path = texture.resource_path
+	
+	var node = self
+	while node:
+		if node.has_signal("visibility_changed"):
+			node.connect("visibility_changed", self, "_on_visibility_changed")
+		node = node.get_parent()
+
+func _on_visibility_changed():
+	if is_visible_in_tree():
+		if not texture and resource_path:
+			texture = load(resource_path)
+	elif texture:
+		texture = null
+
+func set_texture(texture: Texture):
+	resource_path = texture.resource_path
+	if is_visible_in_tree():
+		.set_texture(texture)

--- a/scenes/ui_nodes/LazyTextureRect.tscn
+++ b/scenes/ui_nodes/LazyTextureRect.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://scenes/ui_nodes/LazyTextureRect.gd" type="Script" id=1]
+
+[node name="LazyTextureRect" type="TextureRect"]
+margin_right = 40.0
+margin_bottom = 40.0
+script = ExtResource( 1 )


### PR DESCRIPTION
Some static assets are now only loaded when visible. This reduces background VRAM usage on themes due to loaded elements of RetroHub UI. 