### PR TITLE
Compile engine with size optimizations

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -111,7 +111,7 @@ jobs:
         uses: ./godot/.github/actions/godot-build
         with:
           root: ./godot
-          sconsflags: verbose=yes warnings=all werror=yes bits=${{ matrix.bits }}
+          sconsflags: verbose=yes warnings=all werror=yes use_lto=yes optimize=size bits=${{ matrix.bits }}
           platform: linuxbsd
           target: release
           tools: false

--- a/.github/workflows/mac_build.yml
+++ b/.github/workflows/mac_build.yml
@@ -136,7 +136,7 @@ jobs:
         uses: ./godot/.github/actions/godot-build
         with:
           root: ./godot
-          sconsflags: verbose=yes warnings=all werror=yes arch=x86_64
+          sconsflags: verbose=yes warnings=all werror=yes use_lto=yes optimize=size arch=x86_64
           platform: osx
           target: release
           tools: false
@@ -146,7 +146,7 @@ jobs:
         uses: ./godot/.github/actions/godot-build
         with:
           root: ./godot
-          sconsflags: verbose=yes warnings=all werror=yes arch=arm64
+          sconsflags: verbose=yes warnings=all werror=yes use_lto=yes optimize=size arch=arm64
           platform: osx
           target: release
           tools: false

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -115,7 +115,7 @@ jobs:
         uses: ./godot/.github/actions/godot-build
         with:
           root: ./godot
-          sconsflags: verbose=yes warnings=all werror=yes bits=${{ matrix.bits }}
+          sconsflags: verbose=yes warnings=all werror=yes use_lto=yes bits=${{ matrix.bits }}
           platform: windows
           target: release
           tools: false


### PR DESCRIPTION
- Set compilation to optimize size instead of speed (needs to be tested for performance impacts and, if significant, reverted)
- Enabled LTO, which not only reduces size but also increases performance

EDIT: Size optimization was disabled for Windows due to a compiler bug; needs to be investigated