### PR TITLE
Fix texture corruption on async media calls

### DIFF
--- a/source/Media.gd
+++ b/source/Media.gd
@@ -60,7 +60,7 @@ func t_process_media_requests():
 		_processing_mutex.unlock()
 
 		var media_data := retrieve_media_data(game_data, types)
-		emit_signal("media_loaded", media_data, game_data, types)
+		call_deferred("emit_signal", "media_loaded", media_data, game_data, types)
 
 func _clear_media_cache():
 	_media_cache.clear()


### PR DESCRIPTION
Very fast calls to load async media and cancelling it would result in internal Godot errors on debug builds, and on release "blackout" most textures from theme and all from UI. This seemingly fixes the issue. 