### PR TITLE
Implement proper UI usage for stick movement

### DIFF
--- a/addons/onscreenkeyboard/onscreen_keyboard.gd
+++ b/addons/onscreenkeyboard/onscreen_keyboard.gd
@@ -57,7 +57,7 @@ func _input(event):
 	_updateAutoDisplayOnInput(event)
 	if keyboardVisible:
 		if not sendingEvent:
-			if event is InputEventKey or event is InputEventJoypadButton or event is InputEventJoypadMotion:
+			if event is InputEventKey or event is InputEventJoypadButton or event is InputEventJoypadMotion or event is InputEventAction:
 				get_tree().set_input_as_handled()
 				_handleKeyEvents(event)
 		elif event is InputEventKey and event.scancode == KEY_ENTER and isKeyboardFocusObjectCompleteOnEnter(focusObject):
@@ -201,13 +201,13 @@ func _handleKeyEvents(event):
 	# Manually trigger ControllerIcons to consume event
 	ControllerIcons._input(event)
 	# Selection
-	if event.is_action_pressed("ui_left"):
+	if event.is_action_pressed("ui_left", true):
 		focusKey(focusedKeyX - 1, focusedKeyY)
-	elif event.is_action_pressed("ui_right"):
+	elif event.is_action_pressed("ui_right", true):
 		focusKey(focusedKeyX + 1, focusedKeyY)
-	elif event.is_action_pressed("ui_up"):
+	elif event.is_action_pressed("ui_up", true):
 		focusKeyDir(Direction.UP)
-	elif event.is_action_pressed("ui_down"):
+	elif event.is_action_pressed("ui_down", true):
 		focusKeyDir(Direction.DOWN)
 	elif event.is_action_pressed("ui_accept"):
 		focusKeys[focusedKeyY][focusedKeyX].pressing = true

--- a/scenes/config/settings/InputSettings.gd
+++ b/scenes/config/settings/InputSettings.gd
@@ -8,6 +8,8 @@ onready var n_cn_reset := $"%CNReset"
 onready var n_cn_start_layout := $"%CNStartLayout"
 onready var n_cn_clear_layout := $"%CNClearLayout"
 onready var n_cn_icon_type := $"%CNIconType"
+onready var n_cn_pre_delay := $"%CNPreDelay"
+onready var n_cn_delay := $"%CNDelay"
 
 onready var n_vkb_layout := $"%VirtualKeyboardLayout"
 onready var n_vkb_show_on_controller := $"%VirtualKeyboardOnController"
@@ -38,6 +40,8 @@ func grab_focus():
 func _on_config_ready(config_data: ConfigData):
 	n_cn_clear_layout.disabled = config_data.custom_input_remap.empty()
 	n_cn_icon_type.selected = config_data.input_controller_icon_type
+	n_cn_pre_delay.value = config_data.input_controller_echo_pre_delay
+	n_cn_delay.value = config_data.input_controller_echo_delay
 	match config_data.virtual_keyboard_layout:
 		"qwertz":
 			n_vkb_layout.selected = 1
@@ -136,6 +140,13 @@ func _on_CNIconType_item_selected(index):
 	RetroHubConfig.config.input_controller_icon_type = index
 	ControllerIcons.refresh()
 
+func _on_CNPreDelay_value_changed(value):
+	RetroHubConfig.config.input_controller_echo_pre_delay = value
+
+
+func _on_CNDelay_value_changed(value):
+	RetroHubConfig.config.input_controller_echo_delay = value
+
 
 func _on_KBReset_pressed():
 	RetroHubConfig.config.input_key_map = ConfigData.default_input_key_map()
@@ -164,3 +175,5 @@ func _on_VirtualKeyboardOnController_toggled(button_pressed):
 
 func _on_VirtualKeyboardOnMouse_toggled(button_pressed):
 	RetroHubConfig.config.virtual_keyboard_show_on_mouse = button_pressed
+
+

--- a/scenes/config/settings/InputSettings.tscn
+++ b/scenes/config/settings/InputSettings.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=39 format=2]
+[gd_scene load_steps=40 format=2]
 
 [ext_resource path="res://scenes/config/settings/InputSettings.gd" type="Script" id=1]
 [ext_resource path="res://addons/controller_icons/assets/key/enter_alt.png" type="Texture" id=2]
@@ -38,6 +38,7 @@
 [ext_resource path="res://addons/controller_icons/assets/ps4/cross.png" type="Texture" id=36]
 [ext_resource path="res://addons/controller_icons/assets/steam/a.png" type="Texture" id=37]
 [ext_resource path="res://addons/controller_icons/assets/stadia/a.png" type="Texture" id=38]
+[ext_resource path="res://source/utils/SpinBoxHandler.gd" type="Script" id=39]
 
 [node name="InputSettings" type="Control"]
 anchor_right = 1.0
@@ -398,7 +399,6 @@ path = "rh_right_shoulder"
 force_type = 1
 
 [node name="Controller" type="VBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab"]
-visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0
@@ -417,73 +417,133 @@ align = 1
 valign = 1
 autowrap = true
 
-[node name="HBoxContainer" type="HFlowContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller"]
+[node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller"]
 margin_right = 1016.0
-margin_bottom = 40.0
+margin_bottom = 92.0
 size_flags_horizontal = 3
-custom_constants/hseparation = 8
 
-[node name="CNReset" type="Button" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer"]
+[node name="HBoxContainer4" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer"]
+margin_right = 1016.0
+margin_bottom = 20.0
+
+[node name="CNReset" type="Button" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer4"]
 unique_name_in_owner = true
 margin_right = 172.0
-margin_bottom = 40.0
-focus_neighbour_top = NodePath("../../HBoxContainer2/VBoxContainer/HBoxContainer6/CNThemeMenu")
+margin_bottom = 20.0
+focus_neighbour_top = NodePath("../../../HBoxContainer2/VBoxContainer/HBoxContainer5/CNRetroHubMenu")
 size_flags_horizontal = 0
 text = "Reset to default mapping"
 
-[node name="VSeparator" type="VSeparator" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer"]
-margin_left = 180.0
-margin_right = 184.0
-margin_bottom = 40.0
+[node name="VSeparator" type="VSeparator" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer4"]
+margin_left = 176.0
+margin_right = 180.0
+margin_bottom = 20.0
 
-[node name="CNStartLayout" type="Button" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer"]
+[node name="CNStartLayout" type="Button" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer4"]
 unique_name_in_owner = true
-margin_left = 192.0
-margin_right = 354.0
-margin_bottom = 40.0
-focus_neighbour_top = NodePath("../../HBoxContainer2/VBoxContainer/HBoxContainer6/CNThemeMenu")
+margin_left = 184.0
+margin_right = 346.0
+margin_bottom = 20.0
+focus_neighbour_top = NodePath("../../../HBoxContainer2/VBoxContainer2/HBoxContainer6/CNThemeMenu")
 size_flags_horizontal = 0
 text = "Create controller layout"
 
-[node name="CNClearLayout" type="Button" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer"]
+[node name="CNClearLayout" type="Button" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer4"]
 unique_name_in_owner = true
-margin_left = 362.0
-margin_right = 501.0
-margin_bottom = 40.0
-focus_neighbour_top = NodePath("../../HBoxContainer2/VBoxContainer/HBoxContainer6/CNThemeMenu")
+margin_left = 350.0
+margin_right = 489.0
+margin_bottom = 20.0
+focus_neighbour_top = NodePath("../../../HBoxContainer2/VBoxContainer2/HBoxContainer6/CNThemeMenu")
 size_flags_horizontal = 0
 text = "Clear custom layout"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer"]
-margin_left = 509.0
-margin_right = 876.0
-margin_bottom = 40.0
+[node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer"]
+margin_top = 24.0
+margin_right = 1016.0
+margin_bottom = 64.0
 
-[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer"]
 margin_top = 13.0
 margin_right = 93.0
 margin_bottom = 27.0
 text = "Show icons as:"
 
-[node name="CNIconType" type="OptionButton" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer/HBoxContainer"]
+[node name="CNIconType" type="OptionButton" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 margin_left = 97.0
 margin_right = 367.0
 margin_bottom = 40.0
 rect_min_size = Vector2( 270, 40 )
-focus_neighbour_bottom = NodePath("../../../HBoxContainer2/VBoxContainer/HBoxContainer/CNAccept")
+focus_neighbour_top = NodePath("../../HBoxContainer4/CNReset")
+focus_neighbour_bottom = NodePath("../../HBoxContainer2/CNPreDelay")
 text = "<detect automatically>"
 expand_icon = true
 items = [ "<detect automatically>", null, false, 0, null, "Xbox 360", ExtResource( 28 ), false, 1, null, "Xbox One", ExtResource( 22 ), false, 2, null, "Xbox Series S/X", ExtResource( 30 ), false, 3, null, "PlayStation 3", ExtResource( 35 ), false, 4, null, "PlayStation 4", ExtResource( 36 ), false, 5, null, "PlayStation 5", ExtResource( 33 ), false, 6, null, "Nintendo Switch (Controller)", ExtResource( 31 ), false, 7, null, "Nintendo Switch (Joy-Con)", ExtResource( 31 ), false, 8, null, "Steam Controller", ExtResource( 37 ), false, 9, null, "Steam Deck", ExtResource( 32 ), false, 10, null, "Amazon Luna", ExtResource( 34 ), false, 11, null, "Google Stadia", ExtResource( 38 ), false, 12, null ]
 selected = 0
 
-[node name="HSeparator" type="HSeparator" parent="ScrollContainer/VBoxContainer/InputTab/Controller"]
-margin_top = 44.0
+[node name="HBoxContainer2" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer"]
+margin_top = 68.0
 margin_right = 1016.0
-margin_bottom = 48.0
+margin_bottom = 92.0
+
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer2"]
+margin_top = 5.0
+margin_right = 147.0
+margin_bottom = 19.0
+text = "Input repeat pre-delay:"
+
+[node name="CNPreDelay" type="SpinBox" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer2"]
+unique_name_in_owner = true
+margin_left = 151.0
+margin_right = 225.0
+margin_bottom = 24.0
+focus_neighbour_top = NodePath("../../HBoxContainer/CNIconType")
+focus_neighbour_right = NodePath("../CNDelay")
+focus_neighbour_bottom = NodePath("../../../HBoxContainer2/VBoxContainer/HBoxContainer/CNAccept")
+min_value = 0.1
+max_value = 2.0
+step = 0.1
+value = 0.1
+suffix = "s"
+
+[node name="SpinBoxHandler" type="Control" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer2/CNPreDelay"]
+margin_right = 40.0
+margin_bottom = 40.0
+script = ExtResource( 39 )
+
+[node name="Label2" type="Label" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer2"]
+margin_left = 229.0
+margin_top = 5.0
+margin_right = 350.0
+margin_bottom = 19.0
+text = "Input repeat delay:"
+
+[node name="CNDelay" type="SpinBox" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer2"]
+unique_name_in_owner = true
+margin_left = 354.0
+margin_right = 428.0
+margin_bottom = 24.0
+focus_neighbour_left = NodePath("../CNPreDelay")
+focus_neighbour_top = NodePath("../../HBoxContainer/CNIconType")
+focus_neighbour_bottom = NodePath("../../../HBoxContainer2/VBoxContainer/HBoxContainer/CNAccept")
+min_value = 0.05
+max_value = 1.0
+step = 0.05
+value = 0.05
+suffix = "s"
+
+[node name="SpinBoxHandler" type="Control" parent="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer2/CNDelay"]
+margin_right = 40.0
+margin_bottom = 40.0
+script = ExtResource( 39 )
+
+[node name="HSeparator" type="HSeparator" parent="ScrollContainer/VBoxContainer/InputTab/Controller"]
+margin_top = 96.0
+margin_right = 1016.0
+margin_bottom = 100.0
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller"]
-margin_top = 52.0
+margin_top = 104.0
 margin_right = 1016.0
 margin_bottom = 540.0
 size_flags_horizontal = 3
@@ -491,7 +551,7 @@ size_flags_vertical = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2"]
 margin_right = 506.0
-margin_bottom = 488.0
+margin_bottom = 436.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -511,7 +571,7 @@ margin_left = 458.0
 margin_right = 506.0
 margin_bottom = 48.0
 rect_min_size = Vector2( 48, 48 )
-focus_neighbour_right = NodePath("../../../VBoxContainer2/HBoxContainer/CNPrimaryMov")
+focus_neighbour_right = NodePath("../../../VBoxContainer2/HBoxContainer6/CNThemeMenu")
 icon = ExtResource( 22 )
 expand_icon = true
 script = ExtResource( 26 )
@@ -536,7 +596,7 @@ margin_left = 458.0
 margin_right = 506.0
 margin_bottom = 48.0
 rect_min_size = Vector2( 48, 48 )
-focus_neighbour_right = NodePath("../../../VBoxContainer2/HBoxContainer2/CNSecondaryMov")
+focus_neighbour_right = NodePath("../../../VBoxContainer2/HBoxContainer/CNPrimaryMov")
 icon = ExtResource( 24 )
 expand_icon = true
 script = ExtResource( 26 )
@@ -560,7 +620,7 @@ margin_left = 458.0
 margin_right = 506.0
 margin_bottom = 48.0
 rect_min_size = Vector2( 48, 48 )
-focus_neighbour_right = NodePath("../../../VBoxContainer2/HBoxContainer3/CNSlideLeft")
+focus_neighbour_right = NodePath("../../../VBoxContainer2/HBoxContainer2/CNSecondaryMov")
 icon = ExtResource( 21 )
 expand_icon = true
 script = ExtResource( 26 )
@@ -585,7 +645,7 @@ margin_left = 458.0
 margin_right = 506.0
 margin_bottom = 48.0
 rect_min_size = Vector2( 48, 48 )
-focus_neighbour_right = NodePath("../../../VBoxContainer2/HBoxContainer4/CNSlideRight")
+focus_neighbour_right = NodePath("../../../VBoxContainer2/HBoxContainer3/CNSlideLeft")
 icon = ExtResource( 23 )
 expand_icon = true
 script = ExtResource( 26 )
@@ -611,47 +671,47 @@ margin_right = 506.0
 margin_bottom = 48.0
 rect_min_size = Vector2( 48, 48 )
 focus_neighbour_right = NodePath("../../../VBoxContainer2/HBoxContainer4/CNSlideRight")
+focus_neighbour_bottom = NodePath("../../../../VBoxContainer/HBoxContainer4/CNReset")
 icon = ExtResource( 25 )
 expand_icon = true
 script = ExtResource( 26 )
 path = "rh_menu"
 force_type = 2
 
-[node name="HBoxContainer6" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer"]
-margin_top = 260.0
-margin_right = 506.0
-margin_bottom = 308.0
+[node name="VBoxContainer2" type="VBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2"]
+margin_left = 510.0
+margin_right = 1016.0
+margin_bottom = 436.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
 
-[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer/HBoxContainer6"]
+[node name="HBoxContainer6" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2"]
+margin_right = 506.0
+margin_bottom = 48.0
+
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2/HBoxContainer6"]
 margin_right = 454.0
 margin_bottom = 14.0
 size_flags_horizontal = 3
 size_flags_vertical = 0
 text = "Theme menu"
 
-[node name="CNThemeMenu" type="Button" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer/HBoxContainer6"]
+[node name="CNThemeMenu" type="Button" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2/HBoxContainer6"]
 margin_left = 458.0
 margin_right = 506.0
 margin_bottom = 48.0
 rect_min_size = Vector2( 48, 48 )
-focus_neighbour_right = NodePath("../../../VBoxContainer2/HBoxContainer4/CNSlideRight")
-focus_neighbour_bottom = NodePath("../../../../HBoxContainer/CNReset")
+focus_neighbour_left = NodePath("../../../VBoxContainer/HBoxContainer/CNAccept")
 icon = ExtResource( 27 )
 expand_icon = true
 script = ExtResource( 26 )
 path = "rh_theme_menu"
 force_type = 2
 
-[node name="VBoxContainer2" type="VBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2"]
-margin_left = 510.0
-margin_right = 1016.0
-margin_bottom = 488.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
 [node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2"]
+margin_top = 52.0
 margin_right = 506.0
-margin_bottom = 48.0
+margin_bottom = 100.0
 
 [node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2/HBoxContainer"]
 margin_right = 454.0
@@ -666,7 +726,7 @@ margin_left = 458.0
 margin_right = 506.0
 margin_bottom = 48.0
 rect_min_size = Vector2( 48, 48 )
-focus_neighbour_left = NodePath("../../../VBoxContainer/HBoxContainer/CNAccept")
+focus_neighbour_left = NodePath("../../../VBoxContainer/HBoxContainer2/CNBack")
 icon = ExtResource( 18 )
 expand_icon = true
 script = ExtResource( 26 )
@@ -674,9 +734,9 @@ path = "rh_left"
 force_type = 2
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2"]
-margin_top = 52.0
+margin_top = 104.0
 margin_right = 506.0
-margin_bottom = 100.0
+margin_bottom = 152.0
 
 [node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2/HBoxContainer2"]
 margin_right = 454.0
@@ -691,7 +751,7 @@ margin_left = 458.0
 margin_right = 506.0
 margin_bottom = 48.0
 rect_min_size = Vector2( 48, 48 )
-focus_neighbour_left = NodePath("../../../VBoxContainer/HBoxContainer2/CNBack")
+focus_neighbour_left = NodePath("../../../VBoxContainer/HBoxContainer3/CNMajorOpt")
 icon = ExtResource( 17 )
 expand_icon = true
 script = ExtResource( 26 )
@@ -699,9 +759,9 @@ path = "rh_rstick_left"
 force_type = 2
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2"]
-margin_top = 104.0
+margin_top = 156.0
 margin_right = 506.0
-margin_bottom = 152.0
+margin_bottom = 204.0
 
 [node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2/HBoxContainer3"]
 margin_right = 454.0
@@ -716,7 +776,7 @@ margin_left = 458.0
 margin_right = 506.0
 margin_bottom = 48.0
 rect_min_size = Vector2( 48, 48 )
-focus_neighbour_left = NodePath("../../../VBoxContainer/HBoxContainer3/CNMajorOpt")
+focus_neighbour_left = NodePath("../../../VBoxContainer/HBoxContainer4/CNMinorOpt")
 icon = ExtResource( 19 )
 expand_icon = true
 script = ExtResource( 26 )
@@ -724,9 +784,9 @@ path = "rh_left_shoulder"
 force_type = 2
 
 [node name="HBoxContainer4" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2"]
-margin_top = 156.0
+margin_top = 208.0
 margin_right = 506.0
-margin_bottom = 204.0
+margin_bottom = 256.0
 
 [node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2/HBoxContainer4"]
 margin_right = 454.0
@@ -740,8 +800,8 @@ margin_left = 458.0
 margin_right = 506.0
 margin_bottom = 48.0
 rect_min_size = Vector2( 48, 48 )
-focus_neighbour_left = NodePath("../../../VBoxContainer/HBoxContainer4/CNMinorOpt")
-focus_neighbour_bottom = NodePath("../../../../HBoxContainer/CNReset")
+focus_neighbour_left = NodePath("../../../VBoxContainer/HBoxContainer5/CNRetroHubMenu")
+focus_neighbour_bottom = NodePath("../../../../VBoxContainer/HBoxContainer4/CNReset")
 icon = ExtResource( 20 )
 expand_icon = true
 script = ExtResource( 26 )
@@ -749,6 +809,7 @@ path = "rh_right_shoulder"
 force_type = 2
 
 [node name="Virtual Keyboard" type="VBoxContainer" parent="ScrollContainer/VBoxContainer/InputTab"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0
@@ -869,16 +930,18 @@ margin_bottom = 302.0
 [connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Keyboard/HBoxContainer/VBoxContainer2/HBoxContainer4/KBMoveRight" to="." method="_on_KB_pressed" binds= [ "rh_right" ]]
 [connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Keyboard/HBoxContainer/VBoxContainer2/HBoxContainer5/KBSlideLeft" to="." method="_on_KB_pressed" binds= [ "rh_left_shoulder" ]]
 [connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Keyboard/HBoxContainer/VBoxContainer2/HBoxContainer6/KBSlideRight" to="." method="_on_KB_pressed" binds= [ "rh_right_shoulder" ]]
-[connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer/CNReset" to="." method="_on_CNReset_pressed"]
-[connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer/CNStartLayout" to="." method="_on_StartLayout_pressed"]
-[connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer/CNClearLayout" to="." method="_on_ClearLayout_pressed"]
-[connection signal="item_selected" from="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer/HBoxContainer/CNIconType" to="." method="_on_CNIconType_item_selected"]
+[connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer4/CNReset" to="." method="_on_CNReset_pressed"]
+[connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer4/CNStartLayout" to="." method="_on_StartLayout_pressed"]
+[connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer4/CNClearLayout" to="." method="_on_ClearLayout_pressed"]
+[connection signal="item_selected" from="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer/CNIconType" to="." method="_on_CNIconType_item_selected"]
+[connection signal="value_changed" from="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer2/CNPreDelay" to="." method="_on_CNPreDelay_value_changed"]
+[connection signal="value_changed" from="ScrollContainer/VBoxContainer/InputTab/Controller/VBoxContainer/HBoxContainer2/CNDelay" to="." method="_on_CNDelay_value_changed"]
 [connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer/HBoxContainer/CNAccept" to="." method="_on_CN_pressed" binds= [ "rh_accept" ]]
 [connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer/HBoxContainer2/CNBack" to="." method="_on_CN_pressed" binds= [ "rh_back" ]]
 [connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer/HBoxContainer3/CNMajorOpt" to="." method="_on_CN_pressed" binds= [ "rh_major_option" ]]
 [connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer/HBoxContainer4/CNMinorOpt" to="." method="_on_CN_pressed" binds= [ "rh_minor_option" ]]
 [connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer/HBoxContainer5/CNRetroHubMenu" to="." method="_on_CN_pressed" binds= [ "rh_menu" ]]
-[connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer/HBoxContainer6/CNThemeMenu" to="." method="_on_CN_pressed" binds= [ "rh_theme_menu" ]]
+[connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2/HBoxContainer6/CNThemeMenu" to="." method="_on_CN_pressed" binds= [ "rh_theme_menu" ]]
 [connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2/HBoxContainer/CNPrimaryMov" to="." method="_on_CNAxis_pressed" binds= [ "rh_left" ]]
 [connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2/HBoxContainer2/CNSecondaryMov" to="." method="_on_CNAxis_pressed" binds= [ "rh_rstick_left" ]]
 [connection signal="pressed" from="ScrollContainer/VBoxContainer/InputTab/Controller/HBoxContainer2/VBoxContainer2/HBoxContainer3/CNSlideLeft" to="." method="_on_CN_pressed" binds= [ "rh_left_shoulder" ]]

--- a/scenes/root/Viewport.gd
+++ b/scenes/root/Viewport.gd
@@ -2,19 +2,6 @@ extends Viewport
 
 onready var n_theme_node = $NoTheme
 
-var _joypad_echo_delay := Timer.new()
-var _joypad_echo_interval := Timer.new()
-var _joypad_last_event = null
-
-func _ready():
-	_joypad_echo_delay.wait_time = 1.0
-	_joypad_echo_interval.wait_time = 0.25
-	_joypad_echo_delay.one_shot = true
-	_joypad_echo_delay.connect("timeout", self, "_on_joypad_echo_delay_timeout")
-	_joypad_echo_interval.connect("timeout", self, "_on_joypad_echo_interval_timeout")
-	add_child(_joypad_echo_delay)
-	add_child(_joypad_echo_interval)
-
 func set_theme(node: Node):
 	remove_child(n_theme_node)
 	RetroHubMedia._clear_media_cache()
@@ -22,29 +9,3 @@ func set_theme(node: Node):
 		n_theme_node.queue_free()
 	n_theme_node = node
 	add_child(n_theme_node)
-
-func _on_joypad_echo_delay_timeout():
-	_joypad_echo_interval.start()
-	_on_joypad_echo_interval_timeout()
-
-func _on_joypad_echo_interval_timeout():
-	Input.parse_input_event(_joypad_last_event)
-
-func _input(event):
-	if event == _joypad_last_event:
-		RetroHub._is_echo = true
-		return
-	RetroHub._is_echo = event.is_echo()
-	if event is InputEventJoypadMotion or event is InputEventJoypadButton:
-		if Input.is_action_just_released("ui_left") or Input.is_action_just_released("ui_up") \
-			or Input.is_action_just_released("ui_right") or Input.is_action_just_released("ui_down"):
-			_joypad_echo_delay.stop()
-			_joypad_echo_interval.stop()
-
-		if Input.is_action_pressed("ui_left") or Input.is_action_pressed("ui_up") \
-			or Input.is_action_pressed("ui_right") or Input.is_action_pressed("ui_down"):
-			if _joypad_echo_delay.is_stopped():
-				_joypad_last_event = event
-				_joypad_echo_delay.start()
-			#else:
-				#get_tree().set_input_as_handled()

--- a/source/data/ConfigData.gd
+++ b/source/data/ConfigData.gd
@@ -27,6 +27,8 @@ var input_controller_map : Dictionary = default_input_controller_map() setget _s
 var input_controller_main_axis : int = JOY_ANALOG_LX setget _set_input_controller_main_axis
 var input_controller_secondary_axis : int = JOY_ANALOG_RX setget _set_input_controller_secondary_axis
 var input_controller_icon_type : int = -1 setget _set_input_controller_icon_type
+var input_controller_echo_pre_delay: float = 0.75 setget _set_input_controller_echo_pre_delay
+var input_controller_echo_delay: float = 0.15 setget _set_input_controller_echo_delay
 var virtual_keyboard_layout : String = "qwerty" setget _set_virtual_keyboard_layout
 var virtual_keyboard_show_on_controller : bool = true setget _set_virtual_keyboard_show_on_controller
 var virtual_keyboard_show_on_mouse : bool = false setget _set_virtual_keyboard_show_on_mouse
@@ -51,6 +53,8 @@ const KEY_INPUT_CONTROLLER_MAP = "input_controller_map"
 const KEY_INPUT_CONTROLLER_MAIN_AXIS = "input_controller_main_axis"
 const KEY_INPUT_CONTROLLER_SECONDARY_AXIS = "input_controller_secondary_axis"
 const KEY_INPUT_CONTROLLER_ICON_TYPE = "input_controller_icon_type"
+const KEY_INPUT_CONTROLLER_ECHO_PRE_DELAY = "input_controller_echo_pre_delay"
+const KEY_INPUT_CONTROLLER_ECHO_DELAY = "input_controller_echo_delay"
 const KEY_VIRTUAL_KEYBOARD_LAYOUT = "virtual_keyboard_layout"
 const KEY_VIRTUAL_KEYBOARD_SHOW_ON_CONTROLLER = "virtual_keyboard_show_on_controller"
 const KEY_VIRTUAL_KEYBOARD_SHOW_ON_MOUSE = "virtual_keyboard_show_on_mouse"
@@ -77,6 +81,8 @@ const _keys = [
 	KEY_INPUT_CONTROLLER_MAIN_AXIS,
 	KEY_INPUT_CONTROLLER_SECONDARY_AXIS,
 	KEY_INPUT_CONTROLLER_ICON_TYPE,
+	KEY_INPUT_CONTROLLER_ECHO_PRE_DELAY,
+	KEY_INPUT_CONTROLLER_ECHO_DELAY,
 	KEY_VIRTUAL_KEYBOARD_LAYOUT,
 	KEY_VIRTUAL_KEYBOARD_SHOW_ON_CONTROLLER,
 	KEY_VIRTUAL_KEYBOARD_SHOW_ON_MOUSE
@@ -242,6 +248,14 @@ func _set_input_controller_secondary_axis(_input_controller_secondary_axis):
 func _set_input_controller_icon_type(_input_controller_icon_type):
 	mark_for_saving()
 	input_controller_icon_type = _input_controller_icon_type
+
+func _set_input_controller_echo_pre_delay(_input_controller_echo_pre_delay):
+	mark_for_saving()
+	input_controller_echo_pre_delay = _input_controller_echo_pre_delay
+
+func _set_input_controller_echo_delay(_input_controller_echo_delay):
+	mark_for_saving()
+	input_controller_echo_delay = _input_controller_echo_delay
 
 func _set_virtual_keyboard_layout(_virtual_keyboard_layout):
 	mark_for_saving()

--- a/source/utils/ControllerHandler.gd
+++ b/source/utils/ControllerHandler.gd
@@ -1,28 +1,63 @@
 extends Control
 
 var prev_focus : Control = null
-
 var hyper_focused_control : Control = null
+
+var _joypad_echo_pre_delay := Timer.new()
+var _joypad_echo_delay := Timer.new()
+var _joypad_last_event = null
+var _joypad_motion_last_action = ""
+var _joypad_motion_last_value = 0.0
+var _event_handled := false
 
 func _init():
 	ControllerIcons.connect("input_type_changed", self, "_on_input_type_changed")
 
 func _ready():
+	RetroHubConfig.connect("config_ready", self, "_on_config_ready")
+	RetroHubConfig.connect("config_updated", self, "_on_config_updated")
 	yield(get_tree(), "idle_frame")
 	raise()
+	_joypad_echo_pre_delay.one_shot = true
+	_joypad_echo_pre_delay.connect("timeout", self, "_on_joypad_echo_pre_delay_timeout")
+	_joypad_echo_delay.connect("timeout", self, "_on_joypad_echo_delay_timeout")
+	add_child(_joypad_echo_pre_delay)
+	add_child(_joypad_echo_delay)
+
+func _on_config_ready(config_data: ConfigData):
+	_joypad_echo_pre_delay.wait_time = config_data.input_controller_echo_pre_delay
+	_joypad_echo_delay.wait_time = config_data.input_controller_echo_delay
+
+func _on_config_updated(key: String, old, new):
+	match key:
+		ConfigData.KEY_INPUT_CONTROLLER_ECHO_PRE_DELAY:
+			_joypad_echo_pre_delay.wait_time = new
+		ConfigData.KEY_INPUT_CONTROLLER_ECHO_DELAY:
+			_joypad_echo_delay.wait_time = new
 
 func _on_input_type_changed(input_type):
 	set_process(input_type == ControllerIcons.InputType.CONTROLLER)
 
+func _on_joypad_echo_pre_delay_timeout():
+	_joypad_echo_delay.start()
+	_on_joypad_echo_delay_timeout()
+
+func _on_joypad_echo_delay_timeout():
+	Input.parse_input_event(_joypad_last_event)
+
 func _input(event):
+	_event_handled = false
 	if hyper_focused_control:
 		get_tree().set_input_as_handled()
 	if event is InputEventJoypadButton:
 		_input_button(event)
 	elif event is InputEventJoypadMotion:
 		_input_motion(event)
+	elif event is InputEventAction:
+		_input_hyper_focused(event)
 
 func _input_button(event: InputEventJoypadButton):
+	_input_ui_movement_button(event)
 	var control := get_focus_owner()
 	if hyper_focused_control:
 		_input_hyper_focused(event)
@@ -54,17 +89,120 @@ func _input_button(event: InputEventJoypadButton):
 			hyper_focused_control = null
 
 func _input_motion(event: InputEventJoypadMotion):
-	if hyper_focused_control:
-		_input_hyper_focused(event)
-		
+	_input_ui_movement_motion(event)
+	_input_hyper_focused(event)
+	
+
 func _input_hyper_focused(event):
-	match hyper_focused_control.get_class():
-		"SpinBox":
-			_input_motion_spinbox(event)
+	if hyper_focused_control and not _event_handled:
+		match hyper_focused_control.get_class():
+			"SpinBox":
+				_input_motion_spinbox(event)
 
 func _input_motion_spinbox(event):
 	var spin_box = hyper_focused_control as SpinBox
-	if event.is_action_pressed("rh_up"):
-		spin_box.value += 1
-	if event.is_action_pressed("rh_down"):
-		spin_box.value -= 1
+	if event.is_action_pressed("ui_up"):
+		spin_box.value += spin_box.step
+	if event.is_action_pressed("ui_down"):
+		spin_box.value -= spin_box.step
+
+func _input_ui_movement_button(event: InputEventJoypadButton):
+	if event == _joypad_last_event:
+		return
+	if event.is_action_released("ui_left") or event.is_action_released("ui_up") \
+		or event.is_action_released("ui_right") or event.is_action_released("ui_down"):
+		_joypad_echo_pre_delay.stop()
+		_joypad_echo_delay.stop()
+		#print("Stopping")
+	if event.is_action_pressed("ui_left") or event.is_action_pressed("ui_up") \
+		or event.is_action_pressed("ui_right") or event.is_action_pressed("ui_down"):
+		if _joypad_echo_pre_delay.is_stopped():
+			_joypad_last_event = event
+			_joypad_echo_pre_delay.start()
+			#print("Started")
+
+func _input_ui_movement_motion(event: InputEventJoypadMotion):
+	if event == _joypad_last_event:
+		return
+	var action : String
+	# Godot uses the same action for both directions of an axis, for some reason...
+	if event.is_action("ui_left"):
+		if event.axis_value < 0.0:
+			action = "ui_left"
+		else:
+			action = "ui_right"
+	elif event.is_action("ui_up"):
+		if event.axis_value < 0.0:
+			action = "ui_up"
+		else:
+			action = "ui_down"
+	# This only happens with input bounces (releasing the stick)
+	elif event.is_action("ui_right"):
+		action = "ui_right"
+	elif event.is_action("ui_down"):
+		action = "ui_down"
+	else:
+		return
+	var deadzone = InputMap.action_get_deadzone(action)
+	# If event is the same
+	if action == _joypad_motion_last_action:
+		_mark_event_as_handled()
+		# If event falls behind deadzone, it's considered released
+		if abs(event.get_axis_value()) < deadzone:
+			_joypad_echo_pre_delay.stop()
+			_joypad_echo_delay.stop()
+			_joypad_motion_last_action = ""
+			_joypad_motion_last_value = 0.0
+			#print("Stopping")
+		# Else record this event strength
+		_joypad_motion_last_value = abs(event.axis_value)
+	# Event is different
+	elif not _joypad_motion_last_action.empty():
+		# Is it stronger than current event?
+		_mark_event_as_handled()
+		if abs(event.axis_value) > _joypad_motion_last_value and abs(event.axis_value) > deadzone:
+			_mark_event_as_handled()
+			# Switch to new event
+			_joypad_last_event = _generate_motion_event(action)
+			_joypad_echo_pre_delay.start()
+			_joypad_echo_delay.stop()
+			_joypad_motion_last_action = action
+			_joypad_motion_last_value = abs(event.axis_value)
+			#print("Started (changed to %s)" % _joypad_motion_last_action)
+		# Else is it the opposite event of last frame (happens when stick is released fast and bounces)
+		elif _is_action_opposite(action, _joypad_motion_last_action):
+			_joypad_echo_pre_delay.stop()
+			_joypad_echo_delay.stop()
+			_joypad_motion_last_action = ""
+			_joypad_motion_last_value = 0.0
+			#print("Stopping")
+	# No current event, set this one if surpasses deadzone
+	elif _joypad_motion_last_action.empty() and abs(event.axis_value) > deadzone:
+		_joypad_last_event = _generate_motion_event(action)
+		_joypad_echo_pre_delay.start()
+		_joypad_echo_delay.stop()
+		_joypad_motion_last_action = action
+		_joypad_motion_last_value = abs(event.axis_value)
+		#print("Started (new)")
+
+func _generate_motion_event(action: String):
+	var event = InputEventAction.new()
+	event.pressed = true
+	event.action = action
+	return event
+
+func _is_action_opposite(action1: String, action2: String):
+	match action1:
+		"ui_left":
+			return action2 == "ui_right"
+		"ui_right":
+			return action2 == "ui_left"
+		"ui_up":
+			return action2 == "ui_down"
+		"ui_down":
+			return action2 == "ui_up"
+	return false
+
+func _mark_event_as_handled():
+	get_tree().set_input_as_handled()
+	_event_handled = true


### PR DESCRIPTION
Stick movement can now be used for UI selection without it going completely crazy on selections. Timings are configurable as well.

A few cases likely need to be tackled through engine modifications, such as `ui_left` being used for both left and right movements (noticeable on PopupMenu's)

Closes #6 