### PR TITLE
Bump version to v0.0.7-alpha

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -2,7 +2,7 @@ name: 🐧 Linux Builds
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   pull_request:
 
 jobs:
@@ -147,8 +147,8 @@ jobs:
       - name: "Package default themes"
         uses: ./retrohub/.github/actions/get-default-themes
         with:
-          default-tag: v0.0.4-alpha
-          es-wrapper-tag: v0.0.2-alpha
+          default-tag: v0.0.5-alpha
+          es-wrapper-tag: v0.0.3-alpha
 
       - name: "Exporting RetroHub"
         working-directory: retrohub

--- a/.github/workflows/mac_build.yml
+++ b/.github/workflows/mac_build.yml
@@ -2,7 +2,7 @@ name: 🍎 macOS Builds
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   pull_request:
 
 jobs:
@@ -188,8 +188,8 @@ jobs:
       - name: "Package default themes"
         uses: ./retrohub/.github/actions/get-default-themes
         with:
-          default-tag: v0.0.4-alpha
-          es-wrapper-tag: v0.0.2-alpha
+          default-tag: v0.0.5-alpha
+          es-wrapper-tag: v0.0.3-alpha
 
       - name: "Exporting RetroHub"
         working-directory: retrohub

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -2,7 +2,7 @@ name: 🏁 Windows Builds
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   pull_request:
 
 jobs:
@@ -147,8 +147,8 @@ jobs:
       - name: "Package default themes"
         uses: ./retrohub/.github/actions/get-default-themes
         with:
-          default-tag: v0.0.4-alpha
-          es-wrapper-tag: v0.0.2-alpha
+          default-tag: v0.0.5-alpha
+          es-wrapper-tag: v0.0.3-alpha
 
       - name: "Exporting RetroHub"
         working-directory: retrohub

--- a/source/RetroHub.gd
+++ b/source/RetroHub.gd
@@ -31,7 +31,7 @@ var _is_echo : bool = false
 
 const version_major := 0
 const version_minor := 0
-const version_patch := 6
+const version_patch := 7
 const version_extra := "-alpha"
 const version_str := "%d.%d.%d%s" % [version_major, version_minor, version_patch, version_extra]
 


### PR DESCRIPTION
v0.0.7 is ready :tada:
Also bumped default theme versions

Next version will very likely be the first public v0.1.0 beta, as overall RetroHub is finally ready for general usage.