### PR TITLE
Move sensitive configurations to credentials file

### DIFF
--- a/scenes/config/ScraperSettings.gd
+++ b/scenes/config/ScraperSettings.gd
@@ -21,6 +21,8 @@ onready var n_scrape = $"%Scrape"
 onready var n_scraping_game_picker_popup = $"%ScrapingGamePickerPopup"
 onready var n_scrape_popup = $"%ScraperPopup"
 
+onready var n_ss_settings := $"%ScreenScrapperSettings"
+
 onready var n_media_nodes = [
 	n_media_logo,
 	n_media_title_screen,
@@ -114,6 +116,8 @@ func _on_Scrape_pressed():
 func _on_ScraperSettings_visibility_changed():
 	if visible:
 		update_scrape_stats(true)
+	else:
+		n_ss_settings.save_credentials()
 
 
 func _on_ScraperPopup_popup_hide():

--- a/scenes/config/ScraperSettings.tscn
+++ b/scenes/config/ScraperSettings.tscn
@@ -75,6 +75,7 @@ margin_right = 1012.0
 margin_bottom = 4.0
 
 [node name="ScreenScrapperSettings" parent="VBoxContainer/ScrollContainer/VBoxContainer/CustomSettingsRoot" instance=ExtResource( 3 )]
+unique_name_in_owner = true
 margin_top = 4.0
 margin_right = 1012.0
 margin_bottom = 176.0

--- a/scenes/config/ScreenScrapperSettings.gd
+++ b/scenes/config/ScreenScrapperSettings.gd
@@ -11,8 +11,10 @@ func _ready():
 
 func _on_config_ready(config_data: ConfigData):
 	n_use_account.set_pressed_no_signal(config_data.scraper_ss_use_custom_account)
-	n_username.text = config_data.scraper_ss_username
-	n_password.text = config_data.scraper_ss_password
+	n_username.editable = config_data.scraper_ss_use_custom_account
+	n_password.editable = config_data.scraper_ss_use_custom_account
+	n_username.text = RetroHubConfig._get_credential("scraper_ss_username")
+	n_password.text = RetroHubConfig._get_credential("scraper_ss_password")
 
 
 func _on_ShowPassword_toggled(button_pressed):
@@ -31,3 +33,8 @@ func _on_UseAccount_toggled(button_pressed):
 	RetroHubConfig.config.scraper_ss_use_custom_account = button_pressed
 	n_username.editable = button_pressed
 	n_password.editable = button_pressed
+
+
+func save_credentials():
+	RetroHubConfig._set_credential("scraper_ss_username", n_username.text)
+	RetroHubConfig._set_credential("scraper_ss_password", n_password.text)

--- a/scenes/config/ScreenScrapperSettings.tscn
+++ b/scenes/config/ScreenScrapperSettings.tscn
@@ -147,6 +147,4 @@ fit_content_height = true
 scroll_active = false
 
 [connection signal="toggled" from="HBoxContainer/UseAccount" to="." method="_on_UseAccount_toggled"]
-[connection signal="text_changed" from="HBoxContainer2/Username" to="." method="_on_Username_text_changed"]
 [connection signal="toggled" from="HBoxContainer3/ShowPassword" to="." method="_on_ShowPassword_toggled"]
-[connection signal="text_changed" from="HBoxContainer3/Password" to="." method="_on_Password_text_changed"]

--- a/source/Config.gd
+++ b/source/Config.gd
@@ -202,6 +202,17 @@ func load_config_file():
 		config.save_config_to_path(get_config_file(), true)
 		# TODO: behavior for when file is corrupt
 
+func _get_credential(key: String) -> String:
+	var json : Dictionary = JSONUtils.load_json_file(get_config_dir() + "/rh_credentials.json")
+	if not json.empty() and json.has(key):
+		return json[key]
+	return ""
+
+func _set_credential(key: String, value: String):
+	var json : Dictionary = JSONUtils.load_json_file(get_config_dir() + "/rh_credentials.json")
+	json[key] = value
+	JSONUtils.save_json_file(json, get_config_dir() + "/rh_credentials.json")
+
 func _on_config_updated(key, old_value, new_value):
 	match key:
 		ConfigData.KEY_GAMES_DIR:
@@ -472,6 +483,9 @@ func bootstrap_config_dir():
 				return
 			_file.store_string(JSON.print([], "\t"))
 			_file.close()
+		
+		# Bootstrap credentials file
+		JSONUtils.save_json_file({}, get_config_dir() + "/rh_credentials.json")
 
 func save_config():
 	config.save_config_to_path(get_config_file())

--- a/source/scraper/ScreenScraperScraper.gd
+++ b/source/scraper/ScreenScraperScraper.gd
@@ -194,8 +194,8 @@ func ss_get_api_keys(buf: Array, flag: bool) -> String:
 
 func ss_add_user_account(header_data: Dictionary):
 	if RetroHubConfig.config.scraper_ss_use_custom_account:
-		header_data["ssid"] = RetroHubConfig.config.scraper_ss_username
-		header_data["sspassword"] = RetroHubConfig.config.scraper_ss_password
+		header_data["ssid"] = RetroHubConfig._get_credential("scraper_ss_username")
+		header_data["sspassword"] = RetroHubConfig._get_credential("scraper_ss_password")
 
 func get_ss_system_mapping(system_name) -> int:
 	if ss_system_map.has(system_name):


### PR DESCRIPTION
Sensitive user information (currently ScreenScraper login details) have been moved out of the configuration file. This just removes the "obvious" way to access it and offers no real user protection. Sandboxing will eventually tackle this problem better.

Closes #145 