### PR TITLE
Fully support controller on first-time wizard

### DIFF
--- a/addons/onscreenkeyboard/onscreen_keyboard.gd
+++ b/addons/onscreenkeyboard/onscreen_keyboard.gd
@@ -42,6 +42,11 @@ func _ready():
 	RetroHubConfig.connect("config_ready", self, "on_config_ready")
 	RetroHubConfig.connect("config_updated", self, "on_config_updated")
 
+	# Wait a frame for the config to load
+	yield(get_tree(), "idle_frame")
+	if RetroHubConfig.config.is_first_time:
+		_initKeyboard("qwerty")
+
 func on_config_ready(config_data: ConfigData):
 	_initKeyboard(config_data.virtual_keyboard_layout)
 	autoShow = config_data.virtual_keyboard_show_on_mouse

--- a/project.godot
+++ b/project.godot
@@ -115,6 +115,11 @@ _global_script_classes=[ {
 "path": "res://source/theme/Theme.gd"
 }, {
 "base": "Control",
+"class": "ScrollHandler",
+"language": "GDScript",
+"path": "res://source/utils/ScrollContainerHandler.gd"
+}, {
+"base": "Control",
 "class": "SpinBoxHandler",
 "language": "GDScript",
 "path": "res://source/utils/SpinBoxHandler.gd"
@@ -146,6 +151,7 @@ _global_script_class_icons={
 "RetroHubSupportModel": "",
 "RetroHubSystemData": "",
 "RetroHubTheme": "",
+"ScrollHandler": "",
 "SpinBoxHandler": "",
 "XML2JSON": ""
 }

--- a/scenes/popups/first_time/EmulatorsSection.tscn
+++ b/scenes/popups/first_time/EmulatorsSection.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=3 format=2]
 
-[ext_resource path="res://addons/controller_icons/objects/TextureRect.gd" type="Script" id=1]
 [ext_resource path="res://scenes/popups/first_time/EmulatorsSection.gd" type="Script" id=2]
-[ext_resource path="res://addons/controller_icons/assets/xbox360/r_stick.png" type="Texture" id=3]
+[ext_resource path="res://source/utils/ScrollContainerHandler.gd" type="Script" id=4]
 
 [node name="EmulatorsSection" type="Control"]
 anchor_right = 1.0
@@ -35,48 +34,39 @@ margin_top = 60.0
 margin_right = 1024.0
 margin_bottom = 80.0
 
+[node name="ScrollHandler" type="Control" parent="VBoxContainer/Systems"]
+margin_right = 40.0
+margin_bottom = 40.0
+script = ExtResource( 4 )
+
 [node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer"]
 margin_top = 84.0
 margin_right = 1024.0
-margin_bottom = 568.0
+margin_bottom = 544.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="EmulatorInfoTab" type="TabContainer" parent="VBoxContainer/ScrollContainer"]
 unique_name_in_owner = true
 margin_right = 1024.0
-margin_bottom = 484.0
+margin_bottom = 460.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 tabs_visible = false
 
+[node name="ScrollHandler" type="Control" parent="VBoxContainer/ScrollContainer"]
+script = ExtResource( 4 )
+
 [node name="HSeparator2" type="HSeparator" parent="VBoxContainer"]
-margin_top = 572.0
+margin_top = 548.0
 margin_right = 1024.0
-margin_bottom = 576.0
+margin_bottom = 552.0
 
 [node name="NextButton" type="Button" parent="VBoxContainer"]
-margin_top = 580.0
+margin_top = 556.0
 margin_right = 1024.0
-margin_bottom = 600.0
+margin_bottom = 576.0
 text = "Next"
-
-[node name="ControllerTextureRect" type="TextureRect" parent="."]
-visible = false
-anchor_left = 1.0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = 3.0
-margin_top = -20.0
-margin_right = 43.0
-margin_bottom = 20.0
-rect_min_size = Vector2( 40, 40 )
-texture = ExtResource( 3 )
-expand = true
-script = ExtResource( 1 )
-path = "joypad/r_stick"
-show_only = 2
 
 [connection signal="item_selected" from="VBoxContainer/Systems" to="." method="_on_Systems_item_selected"]
 [connection signal="pressed" from="VBoxContainer/NextButton" to="." method="_on_NextButton_pressed"]

--- a/scenes/popups/first_time/FirstTimePopups.gd
+++ b/scenes/popups/first_time/FirstTimePopups.gd
@@ -5,10 +5,16 @@ export(Color) var color_next := Color(0.5, 0.5, 0.5, 1)
 export(Color) var color_prev := Color(0.4, 0.8, 0.4, 1)
 
 onready var n_sidebar := $"%Sidebar"
-
 onready var n_main_content := $"%MainContent"
+onready var n_rstick_tip := $"%RStickTip"
 
 onready var num_sections := n_sidebar.get_child_count()
+
+func _ready():
+	ControllerIcons.connect("input_type_changed", self, "_on_input_type_changed")
+
+func _on_input_type_changed(input_type: int):
+	n_rstick_tip.visible = input_type == ControllerIcons.InputType.CONTROLLER
 
 func reset_section():
 	n_main_content.current_tab = 0

--- a/scenes/popups/first_time/FirstTimePopups.tscn
+++ b/scenes/popups/first_time/FirstTimePopups.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=2]
+[gd_scene load_steps=19 format=2]
 
 [ext_resource path="res://resources/default_theme.tres" type="Theme" id=1]
 [ext_resource path="res://scenes/popups/first_time/EmulatorsSection.tscn" type="PackedScene" id=2]
@@ -16,8 +16,11 @@
 [ext_resource path="res://scenes/popups/first_time/GamesSection.tscn" type="PackedScene" id=14]
 [ext_resource path="res://scenes/popups/first_time/ImportSettingsSection.tscn" type="PackedScene" id=15]
 [ext_resource path="res://scenes/popups/first_time/SystemsSection.tscn" type="PackedScene" id=16]
+[ext_resource path="res://addons/controller_icons/objects/TextureRect.gd" type="Script" id=17]
+[ext_resource path="res://addons/controller_icons/assets/xboxone/r_stick.png" type="Texture" id=18]
 
 [node name="FirstTimePopup" type="Popup"]
+visible = true
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 28.0
@@ -243,6 +246,37 @@ margin_left = 5.0
 margin_top = 5.0
 margin_right = -5.0
 margin_bottom = -5.0
+
+[node name="RStickTip" type="HBoxContainer" parent="."]
+unique_name_in_owner = true
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+margin_left = -104.0
+margin_right = 104.0
+margin_bottom = 33.0
+size_flags_horizontal = 7
+
+[node name="ControllerTextureRect" type="TextureRect" parent="RStickTip"]
+margin_right = 32.0
+margin_bottom = 33.0
+rect_min_size = Vector2( 32, 32 )
+size_flags_horizontal = 10
+texture = ExtResource( 18 )
+expand = true
+script = ExtResource( 17 )
+path = "rh_rstick_left"
+force_type = 2
+max_width = 32
+
+[node name="Label" type="Label" parent="RStickTip"]
+margin_left = 36.0
+margin_top = 2.0
+margin_right = 208.0
+margin_bottom = 30.0
+size_flags_horizontal = 2
+text = "for scrolling information"
 
 [connection signal="about_to_show" from="." to="." method="_on_FirstTimePopup_about_to_show"]
 [connection signal="popup_hide" from="." to="." method="_on_FirstTimePopup_popup_hide"]

--- a/scenes/popups/first_time/GamesSection.tscn
+++ b/scenes/popups/first_time/GamesSection.tscn
@@ -33,6 +33,7 @@ custom_constants/separation = 15
 unique_name_in_owner = true
 margin_right = 871.0
 margin_bottom = 24.0
+focus_mode = 0
 size_flags_horizontal = 3
 editable = false
 placeholder_text = "<empty>"
@@ -42,6 +43,7 @@ unique_name_in_owner = true
 margin_left = 886.0
 margin_right = 1024.0
 margin_bottom = 24.0
+focus_neighbour_top = NodePath("../../NextButton")
 text = "Choose directory"
 icon = ExtResource( 2 )
 
@@ -64,9 +66,10 @@ autowrap = true
 
 [node name="NextButton" type="Button" parent="VBoxContainer"]
 unique_name_in_owner = true
-margin_top = 580.0
+margin_top = 556.0
 margin_right = 1024.0
-margin_bottom = 600.0
+margin_bottom = 576.0
+focus_neighbour_bottom = NodePath("../HBoxContainer/ChooseDir")
 disabled = true
 text = "Next"
 

--- a/scenes/popups/first_time/ImportSettingsSection.tscn
+++ b/scenes/popups/first_time/ImportSettingsSection.tscn
@@ -36,7 +36,7 @@ margin_bottom = 39.0
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer"]
 margin_top = 43.0
 margin_right = 1024.0
-margin_bottom = 576.0
+margin_bottom = 552.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -45,13 +45,14 @@ unique_name_in_owner = true
 margin_right = 1024.0
 margin_bottom = 60.0
 rect_min_size = Vector2( 0, 60 )
+focus_neighbour_top = NodePath("../../NextButton")
 expand_icon = true
 
 [node name="CompatibilityDetails" type="Control" parent="VBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 margin_top = 64.0
 margin_right = 1024.0
-margin_bottom = 533.0
+margin_bottom = 509.0
 size_flags_vertical = 3
 script = ExtResource( 5 )
 
@@ -61,7 +62,7 @@ anchor_bottom = 1.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/VBoxContainer/CompatibilityDetails/ScrollContainer"]
 margin_right = 1024.0
-margin_bottom = 469.0
+margin_bottom = 445.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_constants/separation = 25
@@ -192,9 +193,10 @@ text = "Details about themes"
 autowrap = true
 
 [node name="NextButton" type="Button" parent="VBoxContainer"]
-margin_top = 580.0
+margin_top = 556.0
 margin_right = 1024.0
-margin_bottom = 600.0
+margin_bottom = 576.0
+focus_neighbour_bottom = NodePath("../VBoxContainer/ImportOptions")
 text = "Next"
 
 [node name="CopyMovePopup" parent="." instance=ExtResource( 3 )]

--- a/scenes/popups/first_time/RegionSection.tscn
+++ b/scenes/popups/first_time/RegionSection.tscn
@@ -67,6 +67,7 @@ unique_name_in_owner = true
 margin_left = 55.0
 margin_right = 110.0
 margin_bottom = 20.0
+focus_neighbour_top = NodePath("../../../../NextButton")
 text = "USA"
 items = [ "USA", null, false, 0, null, "Europe", null, false, 1, null, "Japan", null, false, 2, null ]
 selected = 0
@@ -373,6 +374,7 @@ stretch_mode = 6
 margin_top = 556.0
 margin_right = 1024.0
 margin_bottom = 576.0
+focus_neighbour_bottom = NodePath("../ScrollContainer/VBoxContainer/HBoxContainer/RegionOptions")
 text = "Next"
 
 [connection signal="item_selected" from="VBoxContainer/ScrollContainer/VBoxContainer/HBoxContainer/RegionOptions" to="." method="_on_RegionOptions_item_selected"]

--- a/scenes/popups/first_time/SystemTrees.gd
+++ b/scenes/popups/first_time/SystemTrees.gd
@@ -15,11 +15,20 @@ onready var n_systems := [
 	n_engines, n_modern_consoles
 ]
 
+func _ready():
+	for system in n_systems:
+		system.connect("focus_entered", self, "_on_tree_focus_entered", [system])
+
+func _on_tree_focus_entered(tree: Tree):
+	if not tree.get_selected():
+		tree.get_root().select(1)
+	tree.emit_signal("item_selected")
+
 func grab_focus():
 	for tree in n_systems:
 		if tree.visible:
 			tree.grab_focus()
-			break
+			return
 
 
 func setup_systems(categories: Array):
@@ -30,6 +39,7 @@ func setup_systems(categories: Array):
 		var root : TreeItem = n_systems[idx].create_item()
 		root.set_cell_mode(0, TreeItem.CELL_MODE_CHECK)
 		root.set_checked(0, true)
+		root.set_selectable(0, false)
 		root.set_editable(0, true)
 		root.set_text(1, "<all>")
 
@@ -40,6 +50,7 @@ func setup_systems(categories: Array):
 		child.set_checked(0, system["name"] in RetroHubConfig.systems)
 		set_item_checked_up(child.get_parent())
 		child.set_editable(0, true)
+		child.set_selectable(0, false)
 		child.set_metadata(0, system)
 		child.set_text(1, system["name"])
 	
@@ -76,8 +87,7 @@ func set_item_checked_up(item: TreeItem):
 		item.set_checked(0, all_checked)
 		set_item_checked_up(item.get_parent())
 
-func _on_item_edited(tree: Tree):
-	var edited = tree.get_edited()
+func _on_item_edited(edited: TreeItem):
 	if is_edit_valid(edited):
 		set_item_checked_down(edited.get_children(), edited.is_checked(0))
 		set_item_checked_up(edited.get_parent())
@@ -90,7 +100,7 @@ func is_edit_valid(item: TreeItem):
 	if system:
 		var name = system["name"]
 		if RetroHubConfig.systems.has(name):
-			return RetroHubConfig.systems[name].num_games == 0 
+			return RetroHubConfig.systems[name].num_games == 0
 	return true
 
 func save():
@@ -108,23 +118,19 @@ func _on_item_selected(tree: Tree):
 	emit_signal("system_selected", system)
 
 func _on_Consoles_item_edited():
-	_on_item_edited(n_consoles)
+	_on_item_edited(n_consoles.get_edited())
 
 func _on_Arcades_item_edited():
-	_on_item_edited(n_arcades)
-
+	_on_item_edited(n_arcades.get_edited())
 
 func _on_Computers_item_edited():
-	_on_item_edited(n_computers)
-
+	_on_item_edited(n_computers.get_edited())
 
 func _on_Engines_item_edited():
-	_on_item_edited(n_engines)
-
+	_on_item_edited(n_engines.get_edited())
 
 func _on_ModernConsoles_item_edited():
-	_on_item_edited(n_modern_consoles)
-
+	_on_item_edited(n_modern_consoles.get_edited())
 
 func _on_Consoles_item_selected():
 	_on_item_selected(n_consoles)
@@ -132,14 +138,36 @@ func _on_Consoles_item_selected():
 func _on_Arcades_item_selected():
 	_on_item_selected(n_arcades)
 
-
 func _on_Computers_item_selected():
 	_on_item_selected(n_computers)
-
 
 func _on_Engines_item_selected():
 	_on_item_selected(n_engines)
 
-
 func _on_ModernConsoles_item_selected():
 	_on_item_selected(n_modern_consoles)
+
+func _on_Consoles_item_activated():
+	var item : TreeItem = n_consoles.get_selected()
+	item.set_checked(0, not item.is_checked(0))
+	_on_item_edited(item)
+
+func _on_Arcades_item_activated():
+	var item : TreeItem = n_arcades.get_selected()
+	item.set_checked(0, not item.is_checked(0))
+	_on_item_edited(item)
+
+func _on_Computers_item_activated():
+	var item : TreeItem = n_computers.get_selected()
+	item.set_checked(0, not item.is_checked(0))
+	_on_item_edited(item)
+
+func _on_Engines_item_activated():
+	var item : TreeItem = n_engines.get_selected()
+	item.set_checked(0, not item.is_checked(0))
+	_on_item_edited(item)
+
+func _on_ModernConsoles_item_activated():
+	var item : TreeItem = n_modern_consoles.get_selected()
+	item.set_checked(0, not item.is_checked(0))
+	_on_item_edited(item)

--- a/scenes/popups/first_time/SystemsSection.gd
+++ b/scenes/popups/first_time/SystemsSection.gd
@@ -47,3 +47,7 @@ func _on_SystemTrees_system_selected(system: Dictionary):
 	n_system_info.visible = system != null
 	if system:
 		n_system_info.set_system(system)
+
+
+func _on_Categories_item_activated():
+	n_system_trees.grab_focus()

--- a/scenes/popups/first_time/SystemsSection.tscn
+++ b/scenes/popups/first_time/SystemsSection.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://scenes/popups/first_time/SystemsSection.gd" type="Script" id=1]
 [ext_resource path="res://scenes/popups/first_time/SystemTrees.gd" type="Script" id=2]
 [ext_resource path="res://scenes/popups/first_time/SystemInfo.tscn" type="PackedScene" id=3]
+[ext_resource path="res://source/utils/ScrollContainerHandler.gd" type="Script" id=4]
 
 [node name="SystemsSection" type="Control"]
 anchor_right = 1.0
@@ -37,17 +38,11 @@ margin_bottom = 552.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HBoxContainer"]
-margin_right = 150.0
-margin_bottom = 509.0
-rect_min_size = Vector2( 150, 0 )
-
-[node name="Categories" type="Tree" parent="VBoxContainer/HBoxContainer/ScrollContainer"]
+[node name="Categories" type="Tree" parent="VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 margin_right = 150.0
 margin_bottom = 509.0
-focus_neighbour_right = NodePath("../../ScrollContainer2/SystemTrees")
-size_flags_horizontal = 3
+rect_min_size = Vector2( 150, 0 )
 size_flags_vertical = 3
 column_titles_visible = true
 hide_folding = true
@@ -58,89 +53,111 @@ margin_left = 154.0
 margin_right = 158.0
 margin_bottom = 509.0
 
-[node name="ScrollContainer2" type="ScrollContainer" parent="VBoxContainer/HBoxContainer"]
+[node name="SystemTrees" type="Control" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
 margin_left = 162.0
 margin_right = 342.0
 margin_bottom = 509.0
 rect_min_size = Vector2( 180, 0 )
-
-[node name="SystemTrees" type="Control" parent="VBoxContainer/HBoxContainer/ScrollContainer2"]
-unique_name_in_owner = true
-margin_right = 180.0
-margin_bottom = 509.0
-size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource( 2 )
 
-[node name="Consoles" type="Tree" parent="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees"]
+[node name="Consoles" type="Tree" parent="VBoxContainer/HBoxContainer/SystemTrees"]
 unique_name_in_owner = true
 anchor_right = 1.0
 anchor_bottom = 1.0
-focus_neighbour_left = NodePath("../../../ScrollContainer/Categories")
+focus_neighbour_left = NodePath("../../Categories")
 size_flags_horizontal = 3
 size_flags_vertical = 3
 columns = 2
 column_titles_visible = true
 hide_folding = true
 
-[node name="Arcades" type="Tree" parent="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees"]
-unique_name_in_owner = true
-anchor_right = 1.0
-anchor_bottom = 1.0
-focus_neighbour_left = NodePath("../../../ScrollContainer/Categories")
-size_flags_horizontal = 3
-size_flags_vertical = 3
-columns = 2
-column_titles_visible = true
-hide_folding = true
+[node name="ScrollHandler" type="Control" parent="VBoxContainer/HBoxContainer/SystemTrees/Consoles"]
+margin_right = 40.0
+margin_bottom = 40.0
+script = ExtResource( 4 )
 
-[node name="Computers" type="Tree" parent="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees"]
-unique_name_in_owner = true
-anchor_right = 1.0
-anchor_bottom = 1.0
-focus_neighbour_left = NodePath("../../../ScrollContainer/Categories")
-size_flags_horizontal = 3
-size_flags_vertical = 3
-columns = 2
-column_titles_visible = true
-hide_folding = true
-
-[node name="Engines" type="Tree" parent="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees"]
+[node name="Arcades" type="Tree" parent="VBoxContainer/HBoxContainer/SystemTrees"]
 unique_name_in_owner = true
 visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
-focus_neighbour_left = NodePath("../../../ScrollContainer/Categories")
+focus_neighbour_left = NodePath("../../Categories")
 size_flags_horizontal = 3
 size_flags_vertical = 3
 columns = 2
 column_titles_visible = true
 hide_folding = true
 
-[node name="ModernConsoles" type="Tree" parent="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees"]
+[node name="ScrollHandler" type="Control" parent="VBoxContainer/HBoxContainer/SystemTrees/Arcades"]
+margin_right = 40.0
+margin_bottom = 40.0
+script = ExtResource( 4 )
+
+[node name="Computers" type="Tree" parent="VBoxContainer/HBoxContainer/SystemTrees"]
 unique_name_in_owner = true
 visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
-focus_neighbour_left = NodePath("../../../ScrollContainer/Categories")
+focus_neighbour_left = NodePath("../../Categories")
 size_flags_horizontal = 3
 size_flags_vertical = 3
 columns = 2
 column_titles_visible = true
 hide_folding = true
+
+[node name="ScrollHandler" type="Control" parent="VBoxContainer/HBoxContainer/SystemTrees/Computers"]
+margin_right = 40.0
+margin_bottom = 40.0
+script = ExtResource( 4 )
+
+[node name="Engines" type="Tree" parent="VBoxContainer/HBoxContainer/SystemTrees"]
+unique_name_in_owner = true
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+focus_neighbour_left = NodePath("../../Categories")
+size_flags_horizontal = 3
+size_flags_vertical = 3
+columns = 2
+column_titles_visible = true
+hide_folding = true
+
+[node name="ScrollHandler" type="Control" parent="VBoxContainer/HBoxContainer/SystemTrees/Engines"]
+margin_right = 40.0
+margin_bottom = 40.0
+script = ExtResource( 4 )
+
+[node name="ModernConsoles" type="Tree" parent="VBoxContainer/HBoxContainer/SystemTrees"]
+unique_name_in_owner = true
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+focus_neighbour_left = NodePath("../../Categories")
+size_flags_horizontal = 3
+size_flags_vertical = 3
+columns = 2
+column_titles_visible = true
+hide_folding = true
+
+[node name="ScrollHandler" type="Control" parent="VBoxContainer/HBoxContainer/SystemTrees/ModernConsoles"]
+margin_right = 40.0
+margin_bottom = 40.0
+script = ExtResource( 4 )
 
 [node name="VSeparator2" type="VSeparator" parent="VBoxContainer/HBoxContainer"]
 margin_left = 346.0
 margin_right = 350.0
 margin_bottom = 509.0
 
-[node name="ScrollContainer3" type="ScrollContainer" parent="VBoxContainer/HBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HBoxContainer"]
 margin_left = 354.0
 margin_right = 1024.0
 margin_bottom = 509.0
 size_flags_horizontal = 3
 
-[node name="SystemInfo" parent="VBoxContainer/HBoxContainer/ScrollContainer3" instance=ExtResource( 3 )]
+[node name="SystemInfo" parent="VBoxContainer/HBoxContainer/ScrollContainer" instance=ExtResource( 3 )]
 unique_name_in_owner = true
 anchor_right = 0.0
 anchor_bottom = 0.0
@@ -178,16 +195,22 @@ align = 1
 valign = 1
 autowrap = true
 
-[connection signal="cell_selected" from="VBoxContainer/HBoxContainer/ScrollContainer/Categories" to="." method="_on_Categories_cell_selected"]
-[connection signal="system_selected" from="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees" to="." method="_on_SystemTrees_system_selected"]
-[connection signal="item_edited" from="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees/Consoles" to="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees" method="_on_Consoles_item_edited"]
-[connection signal="item_selected" from="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees/Consoles" to="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees" method="_on_Consoles_item_selected"]
-[connection signal="item_edited" from="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees/Arcades" to="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees" method="_on_Arcades_item_edited"]
-[connection signal="item_selected" from="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees/Arcades" to="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees" method="_on_Arcades_item_selected"]
-[connection signal="item_edited" from="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees/Computers" to="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees" method="_on_Computers_item_edited"]
-[connection signal="item_selected" from="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees/Computers" to="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees" method="_on_Computers_item_selected"]
-[connection signal="item_edited" from="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees/Engines" to="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees" method="_on_Engines_item_edited"]
-[connection signal="item_selected" from="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees/Engines" to="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees" method="_on_Engines_item_selected"]
-[connection signal="item_edited" from="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees/ModernConsoles" to="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees" method="_on_ModernConsoles_item_edited"]
-[connection signal="item_selected" from="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees/ModernConsoles" to="VBoxContainer/HBoxContainer/ScrollContainer2/SystemTrees" method="_on_ModernConsoles_item_selected"]
+[connection signal="cell_selected" from="VBoxContainer/HBoxContainer/Categories" to="." method="_on_Categories_cell_selected"]
+[connection signal="item_activated" from="VBoxContainer/HBoxContainer/Categories" to="." method="_on_Categories_item_activated"]
+[connection signal="system_selected" from="VBoxContainer/HBoxContainer/SystemTrees" to="." method="_on_SystemTrees_system_selected"]
+[connection signal="item_activated" from="VBoxContainer/HBoxContainer/SystemTrees/Consoles" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_Consoles_item_activated"]
+[connection signal="item_edited" from="VBoxContainer/HBoxContainer/SystemTrees/Consoles" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_Consoles_item_edited"]
+[connection signal="item_selected" from="VBoxContainer/HBoxContainer/SystemTrees/Consoles" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_Consoles_item_selected"]
+[connection signal="item_activated" from="VBoxContainer/HBoxContainer/SystemTrees/Arcades" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_Arcades_item_activated"]
+[connection signal="item_edited" from="VBoxContainer/HBoxContainer/SystemTrees/Arcades" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_Arcades_item_edited"]
+[connection signal="item_selected" from="VBoxContainer/HBoxContainer/SystemTrees/Arcades" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_Arcades_item_selected"]
+[connection signal="item_activated" from="VBoxContainer/HBoxContainer/SystemTrees/Computers" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_Computers_item_activated"]
+[connection signal="item_edited" from="VBoxContainer/HBoxContainer/SystemTrees/Computers" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_Computers_item_edited"]
+[connection signal="item_selected" from="VBoxContainer/HBoxContainer/SystemTrees/Computers" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_Computers_item_selected"]
+[connection signal="item_activated" from="VBoxContainer/HBoxContainer/SystemTrees/Engines" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_Engines_item_activated"]
+[connection signal="item_edited" from="VBoxContainer/HBoxContainer/SystemTrees/Engines" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_Engines_item_edited"]
+[connection signal="item_selected" from="VBoxContainer/HBoxContainer/SystemTrees/Engines" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_Engines_item_selected"]
+[connection signal="item_activated" from="VBoxContainer/HBoxContainer/SystemTrees/ModernConsoles" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_ModernConsoles_item_activated"]
+[connection signal="item_edited" from="VBoxContainer/HBoxContainer/SystemTrees/ModernConsoles" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_ModernConsoles_item_edited"]
+[connection signal="item_selected" from="VBoxContainer/HBoxContainer/SystemTrees/ModernConsoles" to="VBoxContainer/HBoxContainer/SystemTrees" method="_on_ModernConsoles_item_selected"]
 [connection signal="pressed" from="VBoxContainer/NextButton" to="." method="_on_NextButton_pressed"]

--- a/scenes/root/FileSystemPopup.gd
+++ b/scenes/root/FileSystemPopup.gd
@@ -1,0 +1,97 @@
+extends FileDialog
+
+var ok_button : Button
+var cancel_button : Button
+var upwards_button : Button
+var refresh_button : Button
+var hide_button : Button
+
+func _ready():
+	## Normal nodes
+	var tree : Tree = get_vbox().get_child(2).get_child(0)
+	ok_button = get_ok()
+	cancel_button = get_cancel()
+	upwards_button = get_vbox().get_child(0).get_child(0)
+	refresh_button = get_vbox().get_child(0).get_child(4)
+	hide_button = get_vbox().get_child(0).get_child(5)
+	var path : String
+	var controller_icon_rect := preload("res://addons/controller_icons/objects/TextureRect.gd")
+
+	# Attach ControllerIcons to buttons
+	var box : HBoxContainer = ok_button.get_parent()
+	var back_icon := create_icon(controller_icon_rect, "rh_back")
+	box.add_child_below_node(box.get_child(0), back_icon)
+	var select_icon := create_icon(controller_icon_rect, "rh_major_option")
+	box.add_child_below_node(box.get_child(3), select_icon)
+	
+	box = upwards_button.get_parent()
+	var upwards_icon = create_icon(controller_icon_rect, "rh_minor_option")
+	box.add_child(upwards_icon)
+	box.move_child(upwards_icon, 0)
+	var refresh_icon = create_icon(controller_icon_rect, "rh_theme_menu")
+	box.add_child_below_node(box.get_child(4), refresh_icon)
+	var hide_icon = create_icon(controller_icon_rect, "rh_menu")
+	box.add_child_below_node(box.get_child(6), hide_icon)
+
+	# Tree should focus cancel button on down
+	path = "../../../%s/%s" % [
+		cancel_button.get_parent().name,
+		cancel_button.name
+	]
+	tree.focus_neighbour_bottom = path
+	# Ok and Cancel buttons should focus tree on up
+	path = "../../%s/%s/%s" % [
+		tree.get_parent().get_parent().name,
+		tree.get_parent().name,
+		tree.name
+	]
+	ok_button.focus_neighbour_top = path
+	cancel_button.focus_neighbour_top = path
+	
+	## Create Folder nodes
+	var create_folder_popup : ConfirmationDialog = get_child(5)
+	var create_folder_line_edit : LineEdit = create_folder_popup.get_child(3).get_child(1).get_child(0)
+	var create_folder_ok_button := create_folder_popup.get_ok()
+	var create_folder_cancel_button := create_folder_popup.get_cancel()
+	
+	# Set focus neighbors
+	# Line edit should focus cancel button on down
+	path = "../../../%s/%s" % [
+		create_folder_cancel_button.get_parent().name,
+		create_folder_cancel_button.name
+	]
+	create_folder_line_edit.focus_neighbour_bottom = path
+	
+	# Ok and Cancel buttons should focus line edit on up
+	path = "../../%s/%s/%s" % [
+		create_folder_line_edit.get_parent().get_parent().name,
+		create_folder_line_edit.get_parent().name,
+		create_folder_line_edit.name
+	]
+	create_folder_ok_button.focus_neighbour_top = path
+	create_folder_cancel_button.focus_neighbour_top = path
+
+func _unhandled_input(event):
+	if RetroHub.is_input_echo() or not visible:
+		return
+	if event is InputEventJoypadButton:
+		if event.is_action_released("rh_major_option"):
+			get_tree().set_input_as_handled()
+			ok_button.emit_signal("pressed")
+		elif event.is_action_released("rh_minor_option"):
+			get_tree().set_input_as_handled()
+			upwards_button.emit_signal("pressed")
+		elif event.is_action_released("rh_theme_menu"):
+			get_tree().set_input_as_handled()
+			refresh_button.emit_signal("pressed")
+		elif event.is_action_released("rh_menu"):
+			get_tree().set_input_as_handled()
+			hide_button.pressed = not hide_button.pressed
+
+func create_icon(base: GDScript, path: String) -> Control:
+	var icon : Control = base.new()
+	icon.path = path
+	icon.max_width = 32
+	icon.show_only = 2
+	
+	return icon

--- a/scenes/root/Root.tscn
+++ b/scenes/root/Root.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://scenes/root/Root.gd" type="Script" id=1]
 [ext_resource path="res://addons/onscreenkeyboard/onscreen_keyboard.gd" type="Script" id=2]
 [ext_resource path="res://scenes/config/ConfigPopup.tscn" type="PackedScene" id=3]
 [ext_resource path="res://scenes/root/Viewport.gd" type="Script" id=4]
 [ext_resource path="res://resources/default_theme.tres" type="Theme" id=5]
+[ext_resource path="res://scenes/root/FileSystemPopup.gd" type="Script" id=6]
 [ext_resource path="res://scenes/no_theme/NoTheme.tscn" type="PackedScene" id=10]
 
 [sub_resource type="Shader" id=1]
@@ -65,6 +66,7 @@ window_title = "Open a File"
 mode = 0
 access = 2
 show_hidden_files = true
+script = ExtResource( 6 )
 
 [node name="Keyboard" type="PopupPanel" parent="."]
 unique_name_in_owner = true

--- a/source/utils/ControllerHandler.gd
+++ b/source/utils/ControllerHandler.gd
@@ -14,19 +14,16 @@ func _init():
 	ControllerIcons.connect("input_type_changed", self, "_on_input_type_changed")
 
 func _ready():
-	RetroHubConfig.connect("config_ready", self, "_on_config_ready")
 	RetroHubConfig.connect("config_updated", self, "_on_config_updated")
 	yield(get_tree(), "idle_frame")
 	raise()
+	_joypad_echo_pre_delay.wait_time = RetroHubConfig.config.input_controller_echo_pre_delay
+	_joypad_echo_delay.wait_time = RetroHubConfig.config.input_controller_echo_delay
 	_joypad_echo_pre_delay.one_shot = true
 	_joypad_echo_pre_delay.connect("timeout", self, "_on_joypad_echo_pre_delay_timeout")
 	_joypad_echo_delay.connect("timeout", self, "_on_joypad_echo_delay_timeout")
 	add_child(_joypad_echo_pre_delay)
 	add_child(_joypad_echo_delay)
-
-func _on_config_ready(config_data: ConfigData):
-	_joypad_echo_pre_delay.wait_time = config_data.input_controller_echo_pre_delay
-	_joypad_echo_delay.wait_time = config_data.input_controller_echo_delay
 
 func _on_config_updated(key: String, old, new):
 	match key:

--- a/source/utils/ScrollContainerHandler.gd
+++ b/source/utils/ScrollContainerHandler.gd
@@ -1,0 +1,78 @@
+extends Control
+class_name ScrollHandler
+
+## Handles sliding through controller secondary input. Add as a child of a scrollable node.
+## Supports nodes with scroll bars:
+## - ScrollContainer
+## - Tree
+## - OptionButton
+## - PopupMenu
+
+var scroll_h : HScrollBar = null
+var scroll_v : VScrollBar = null
+var scroll_h_speed := 0.0
+var scroll_v_speed := 0.0
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	# This _ready is called before parent, we need to wait a frame for parent to initialize
+	mouse_filter = MOUSE_FILTER_IGNORE
+	yield(get_tree(), "idle_frame")
+	var parent = get_parent()
+	if parent is ScrollContainer:
+		_handle_scroll_container(parent)
+	elif parent is Tree:
+		_handle_tree(parent)
+	elif parent is OptionButton:
+		_handle_popup_menu(parent.get_popup())
+	elif parent is PopupMenu:
+		_handle_popup_menu(parent)
+
+	if not scroll_h and not scroll_v:
+		printerr("ScrollHandler added to a non-scrollable node! Queueing free...")
+		queue_free()
+
+func _handle_scroll_container(node: ScrollContainer):
+	if node.scroll_horizontal_enabled:
+		scroll_h = node.get_h_scrollbar()
+	if node.scroll_vertical_enabled:
+		scroll_v = node.get_v_scrollbar()
+
+func _handle_tree(node: Tree):
+	for child in node.get_children():
+		if child == self:
+			continue
+		if child is HScrollBar:
+			scroll_h = child
+		if child is VScrollBar:
+			scroll_v = child
+
+func _handle_popup_menu(node: PopupMenu):
+	if node.get_child_count() < 0:
+		return
+	
+	for child in node.get_child(0).get_children():
+		if child is ScrollContainer:
+			_handle_scroll_container(child)
+			return
+
+func _process(delta):
+	if not scroll_h and not scroll_v:
+		return
+
+	if scroll_h:
+		scroll_h.value += scroll_h_speed * delta * 500
+	if scroll_v:
+		scroll_v.value += scroll_v_speed * delta * 500
+
+func _unhandled_input(event):
+	if (not scroll_h and not scroll_v) or \
+		(not scroll_h.is_visible_in_tree() and not scroll_v.is_visible_in_tree()) or \
+		RetroHub.is_input_echo():
+		return
+
+	if scroll_h and (event.is_action("rh_rstick_left") or event.is_action("rh_rstick_right")):
+		scroll_h_speed = Input.get_axis("rh_rstick_left", "rh_rstick_right")
+		get_tree().set_input_as_handled()
+	if scroll_v and (event.is_action("rh_rstick_up") or event.is_action("rh_rstick_down")):
+		scroll_v_speed = Input.get_axis("rh_rstick_up", "rh_rstick_down")
+		get_tree().set_input_as_handled()


### PR DESCRIPTION
Ensured full support for controller for the first-time wizard. Some things external to this were also implemented:

- Added controller support for the file/directory dialog
- Added `ScrollHandler`, usable for any scrollable node to scroll wth R-Stick
- Modified Godot's Tree behavior for proper focused node control