### PR TITLE
Implement RetroArch emulator configuration on systems

### DIFF
--- a/scenes/config/settings/SystemSettings.gd
+++ b/scenes/config/settings/SystemSettings.gd
@@ -13,7 +13,7 @@ onready var n_restore_system := $"%RestoreSystem"
 onready var n_select_extensions_popup := $"%SelectExtensionsPopup"
 onready var n_add_custom_info_popup := $"%AddCustomInfoPopup"
 onready var n_add_existing_info_popup := $"%AddExistingInfoPopup"
-
+onready var n_retro_arch_config := $"%RetroArchConfig"
 
 var sep_idx := -1
 
@@ -164,3 +164,18 @@ func _on_AddExistingInfoPopup_identifier_picked(emulator_name: String):
 	n_system_editor.emulators.append(added_info)
 	n_system_editor.add_emulator(added_info)
 	_on_SystemEditor_change_ocurred()
+
+
+func _on_SystemEditor_request_retroarch_config(existing_cores: Array):
+	var retroarch_config : Dictionary = RetroHubConfig.emulators_map["retroarch"]
+	var cores := []
+	for name in existing_cores:
+		for core in retroarch_config["cores"]:
+			if core["name"] == name:
+				cores.push_back(core)
+				break
+	n_retro_arch_config.start(retroarch_config["cores"], cores)
+
+
+func _on_RetroArchConfig_cores_picked(cores):
+	n_system_editor.set_retroarch_cores(cores)

--- a/scenes/config/settings/SystemSettings.tscn
+++ b/scenes/config/settings/SystemSettings.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://scenes/config/settings/SystemSettings.gd" type="Script" id=1]
 [ext_resource path="res://scenes/config/settings/system/SystemEditor.tscn" type="PackedScene" id=2]
 [ext_resource path="res://scenes/config/settings/system/SelectExtensionsPopup.tscn" type="PackedScene" id=3]
 [ext_resource path="res://scenes/config/settings/AddCustomInfo.tscn" type="PackedScene" id=4]
 [ext_resource path="res://scenes/config/settings/AddExistingInfo.tscn" type="PackedScene" id=5]
+[ext_resource path="res://scenes/config/settings/system/RetroArchConfig.tscn" type="PackedScene" id=6]
 
 [node name="SystemSettings" type="Control"]
 anchor_right = 1.0
@@ -117,22 +118,22 @@ focus_neighbour_top = NodePath("../../../../../HBoxContainer/SystemSelection")
 [node name="Logo" parent="VBoxContainer/ScrollContainer/SystemEditor/HBoxContainer/VBoxContainer2" index="1"]
 focus_neighbour_top = NodePath("../../../../../HBoxContainer/SystemSelection")
 
-[node name="Category" parent="VBoxContainer/ScrollContainer/SystemEditor/HBoxContainer4" index="1"]
-items = [ "Console", null, false, 0, null, "Arcade", null, false, 1, null, "Computer", null, false, 2, null, "Game Engine", null, false, 3, null, "Modern Console", null, false, 4, null ]
-
 [node name="Emulators" parent="VBoxContainer/ScrollContainer/SystemEditor" index="7"]
 margin_bottom = 520.0
 focus_neighbour_bottom = NodePath("../../../HBoxContainer/SystemSelection")
 
 [node name="SelectExtensionsPopup" parent="." instance=ExtResource( 3 )]
 unique_name_in_owner = true
-visible = false
 
 [node name="AddCustomInfoPopup" parent="." instance=ExtResource( 4 )]
 unique_name_in_owner = true
 
 [node name="AddExistingInfoPopup" parent="." instance=ExtResource( 5 )]
 unique_name_in_owner = true
+
+[node name="RetroArchConfig" parent="." instance=ExtResource( 6 )]
+unique_name_in_owner = true
+visible = false
 
 [connection signal="visibility_changed" from="." to="." method="_on_SystemSettings_visibility_changed"]
 [connection signal="item_selected" from="VBoxContainer/HBoxContainer/SystemSelection" to="." method="_on_SystemSelection_item_selected"]
@@ -144,8 +145,10 @@ unique_name_in_owner = true
 [connection signal="change_ocurred" from="VBoxContainer/ScrollContainer/SystemEditor" to="." method="_on_SystemEditor_change_ocurred"]
 [connection signal="request_add_emulator" from="VBoxContainer/ScrollContainer/SystemEditor" to="." method="_on_SystemEditor_request_add_emulator"]
 [connection signal="request_extensions" from="VBoxContainer/ScrollContainer/SystemEditor" to="." method="_on_SystemEditor_request_extensions"]
+[connection signal="request_retroarch_config" from="VBoxContainer/ScrollContainer/SystemEditor" to="." method="_on_SystemEditor_request_retroarch_config"]
 [connection signal="extensions_picked" from="SelectExtensionsPopup" to="." method="_on_SelectExtensionsPopup_extensions_picked"]
 [connection signal="identifier_picked" from="AddCustomInfoPopup" to="." method="_on_AddCustomInfoPopup_identifier_picked"]
 [connection signal="identifier_picked" from="AddExistingInfoPopup" to="." method="_on_AddExistingInfoPopup_identifier_picked"]
+[connection signal="cores_picked" from="RetroArchConfig" to="." method="_on_RetroArchConfig_cores_picked"]
 
 [editable path="VBoxContainer/ScrollContainer/SystemEditor"]

--- a/scenes/config/settings/system/RetroArchConfig.gd
+++ b/scenes/config/settings/system/RetroArchConfig.gd
@@ -1,0 +1,84 @@
+extends WindowDialog
+
+signal cores_picked(cores)
+
+onready var n_core_options := $"%CoreOptions"
+onready var n_add_core := $"%AddCore"
+onready var n_cores := $"%Cores"
+
+onready var n_ok := $"%OK"
+
+var root : TreeItem
+
+func _ready():
+	n_core_options.get_popup().max_height = 300
+	n_cores.set_column_expand(0, true)
+	n_cores.set_column_expand(1, false)
+	n_cores.set_column_min_width(1, 48)
+
+func start(cores: Array, existing: Array):
+	reset()
+
+	# Add new cores to list
+	for core in cores:
+		if not core in existing:
+			add_core_option(core)
+
+	# Setup tree
+	root = n_cores.create_item()
+	for core in existing:
+		add_core(core)
+
+	# Popup
+	popup_centered()
+	yield(get_tree(), "idle_frame")
+	n_core_options.grab_focus()
+	n_add_core.disabled = n_core_options.get_child_count() == 0
+
+func reset():
+	n_core_options.clear()
+	n_cores.clear()
+	root = null
+
+func add_core_option(core: Dictionary):
+	var text = "<%s>" % core["name"] if core["fullname"].empty() else core["fullname"]
+	n_core_options.add_item(text)
+	n_core_options.set_item_metadata(n_core_options.get_item_count()-1, core)
+
+func add_core(core: Dictionary):
+	var child = n_cores.create_item(root)
+	child.set_metadata(0, core)
+	var text = "<%s>" % core["name"] if core["fullname"].empty() else core["fullname"]
+	child.set_text(0, text)
+	child.set_icon(1, preload("res://assets/icons/failure.svg"))
+
+func _on_OK_pressed():
+	hide()
+	var cores := []
+	var item = root.get_children()
+	while item != null:
+		cores.push_back(item.get_metadata(0))
+		item = item.get_next()
+
+	emit_signal("cores_picked", cores)
+
+
+func _on_Cores_item_activated():
+	if n_cores.get_selected_column() == 1:
+		# Remove
+		var core = n_cores.get_selected().get_metadata(0)
+		add_core_option(core)
+		n_add_core.disabled = false
+		n_cores.get_selected().free()
+
+
+func _on_AddCore_pressed():
+	var core = n_core_options.get_selected_metadata()
+	add_core(core)
+	var idx = n_core_options.get_item_index(n_core_options.get_selected_id())
+	n_core_options.remove_item(idx)
+	idx -= 1
+	if idx < 0 and n_core_options.get_item_count() > 0:
+		idx = 0
+	n_core_options.selected = idx
+	n_add_core.disabled = n_core_options.get_item_count() == 0

--- a/scenes/config/settings/system/RetroArchConfig.tscn
+++ b/scenes/config/settings/system/RetroArchConfig.tscn
@@ -1,0 +1,88 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://scenes/config/settings/system/RetroArchConfig.gd" type="Script" id=1]
+
+[node name="RetroArchConfig" type="WindowDialog"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -269.5
+margin_top = -178.5
+margin_right = 269.5
+margin_bottom = 178.5
+script = ExtResource( 1 )
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 10.0
+margin_top = 10.0
+margin_right = -10.0
+margin_bottom = -10.0
+
+[node name="Label" type="Label" parent="VBoxContainer"]
+margin_right = 519.0
+margin_bottom = 14.0
+text = "Select a core to add:"
+align = 1
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 18.0
+margin_right = 519.0
+margin_bottom = 38.0
+size_flags_horizontal = 3
+
+[node name="CoreOptions" type="OptionButton" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+margin_right = 478.0
+margin_bottom = 20.0
+focus_neighbour_top = NodePath("../../OK")
+size_flags_horizontal = 3
+clip_text = true
+
+[node name="AddCore" type="Button" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+margin_left = 482.0
+margin_right = 519.0
+margin_bottom = 20.0
+text = "Add"
+
+[node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
+margin_top = 42.0
+margin_right = 519.0
+margin_bottom = 46.0
+
+[node name="Label2" type="Label" parent="VBoxContainer"]
+margin_top = 50.0
+margin_right = 519.0
+margin_bottom = 64.0
+text = "Remove existing cores:"
+align = 1
+
+[node name="Cores" type="Tree" parent="VBoxContainer"]
+unique_name_in_owner = true
+margin_top = 68.0
+margin_right = 519.0
+margin_bottom = 313.0
+focus_neighbour_bottom = NodePath("../OK")
+size_flags_horizontal = 3
+size_flags_vertical = 3
+columns = 2
+hide_root = true
+single_click_select = true
+
+[node name="OK" type="Button" parent="VBoxContainer"]
+unique_name_in_owner = true
+margin_left = 244.0
+margin_top = 317.0
+margin_right = 274.0
+margin_bottom = 337.0
+focus_neighbour_bottom = NodePath("../HBoxContainer/CoreOptions")
+size_flags_horizontal = 4
+size_flags_vertical = 8
+text = "Ok"
+
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/AddCore" to="." method="_on_AddCore_pressed"]
+[connection signal="item_activated" from="VBoxContainer/Cores" to="." method="_on_Cores_item_activated"]
+[connection signal="pressed" from="VBoxContainer/OK" to="." method="_on_OK_pressed"]

--- a/scenes/config/settings/system/SelectExtensionsPopup.tscn
+++ b/scenes/config/settings/system/SelectExtensionsPopup.tscn
@@ -3,7 +3,6 @@
 [ext_resource path="res://scenes/config/settings/system/SelectExtensionsPopup.gd" type="Script" id=1]
 
 [node name="SelectExtensionsPopup" type="WindowDialog"]
-visible = true
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5

--- a/scenes/config/settings/system/SystemEditor.tscn
+++ b/scenes/config/settings/system/SystemEditor.tscn
@@ -187,6 +187,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 columns = 3
 hide_root = true
+single_click_select = true
 
 [connection signal="text_changed" from="HBoxContainer3/Name" to="." method="_on_item_change"]
 [connection signal="item_selected" from="HBoxContainer4/Category" to="." method="_on_item_change"]

--- a/source/RetroHub.gd
+++ b/source/RetroHub.gd
@@ -132,7 +132,7 @@ func _launch_game_process() -> int:
 			var system_cores : Array = system_emulator["retroarch"]
 			emulator = RetroHubRetroArchEmulator.new(emulators["retroarch"], launched_game_data, system_cores)
 			break
-		else:
+		elif emulators.has(system_emulator):
 			emulator = RetroHubGenericEmulator.new(emulators[system_emulator], launched_game_data)
 			break
 


### PR DESCRIPTION
Closes #96.

RetroArch cores can now be configures in-app the systems screen. With this, RetroArch can now be fully configurated without manual edits.

![image](https://user-images.githubusercontent.com/6501975/222707309-d00c4727-6025-42a0-9423-d86323a462b2.png)
