### PR TITLE
Enable signing macOS executables

### DIFF
--- a/.github/workflows/mac_build.yml
+++ b/.github/workflows/mac_build.yml
@@ -195,6 +195,12 @@ jobs:
         working-directory: retrohub
         run: |
           ../cached_builds/editor/Godot.app/Contents/MacOS/Godot --export "Mac" ../export/macos/RetroHub.app
+        
+      - name: "Sign executable"
+        working-directory: export/macos
+        run: |
+          xattr -dr com.apple.quarantine "RetroHub.app"
+          codesign -s - --force --deep "RetroHub.app"
 
       - name: "Upload Artifacts"
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Due to using a custom Godot version, and not being rich to throw money at Apple (not that I'd want to anyway), the app cannot be notarized and will always be a pain point for users. However, the current releases are not working, so hopefully code signing should fix this.