### PR TITLE
Increase message queue buffer

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -349,6 +349,11 @@ rh_rstick_down={
 
 locale_filter=[ 0, [  ] ]
 
+[memory]
+
+limits/message_queue/max_size_kb=32768
+limits/command_queue/multithreading_queue_size_kb=1024
+
 [physics]
 
 common/enable_pause_aware_picking=true


### PR DESCRIPTION
The default 4096KB (4MB) is too low for very large libraries, resulting in a freeze and error spam. It was increased to 32MB.

Related to #195, but not truly closed until the dynamic resize patch is added.