### PR TITLE
Fix texture corruption on async media calls (again)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -360,5 +360,6 @@ common/enable_pause_aware_picking=true
 
 [rendering]
 
+threads/thread_model=2
 environment/default_clear_color=Color( 0.188235, 0.235294, 0.290196, 1 )
 environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
The texture corruption issue still happens when switching systems very quickly on the default theme, resulting in a lot of cancel requests. Seems like the same resource pointer would be used, corrupting elements of RetroHub's UI. Setting the threaded model of the render server seems to fix this.