### PR TITLE
Emulator info screens

### DIFF
--- a/scenes/config/ConfigPopup.gd
+++ b/scenes/config/ConfigPopup.gd
@@ -29,10 +29,8 @@ func _input(event: InputEvent):
 				get_tree().set_input_as_handled()
 				if not visible:
 					popup()
-					n_game.set_game_data(RetroHub.curr_game_data)
 				else:
 					hide()
-					RetroHubConfig.save_theme_config()
 
 func _on_Tab_pressed(idx: int):
 	n_main.current_tab = idx
@@ -54,6 +52,7 @@ func _on_QuitTab_pressed():
 	n_main.current_tab = 0
 
 func _on_ConfigPopup_about_to_show():
+	n_game.set_game_data(RetroHub.curr_game_data)
 	yield(get_tree(), "idle_frame")
 	if last_tab:
 		last_tab.grab_focus()
@@ -75,6 +74,7 @@ func _on_ConfigPopup_popup_hide():
 		RetroHubConfig.load_user_data()
 		RetroHub.load_theme()
 	should_reload_theme = false
+	RetroHubConfig.save_theme_config()
 
 
 func _on_theme_reload():

--- a/scenes/config/settings/input/ControllerLayout.tscn
+++ b/scenes/config/settings/input/ControllerLayout.tscn
@@ -10,6 +10,7 @@
 [ext_resource path="res://resources/fonts/default_italic.tres" type="DynamicFont" id=8]
 
 [node name="ControllerLayout" type="WindowDialog"]
+visible = true
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5

--- a/scenes/game_launched/GameLaunched.gd
+++ b/scenes/game_launched/GameLaunched.gd
@@ -1,10 +1,17 @@
-extends CenterContainer
-
-var game_data : RetroHubGameData setget set_game_data
-var label_text : String
+extends Control
 
 var low_cpu_mode_orig : bool
 var low_cpu_mode_sleep_orig : int
+
+onready var n_emu_logo := $"%EmuLogo"
+onready var n_game_name := $"%GameName"
+onready var n_emu_name := $"%EmuName"
+
+onready var n_kill_press_progress := $"%KillPressProgress"
+onready var n_timer := $"%Timer"
+
+onready var game_name_orig_text : String = n_game_name.text
+onready var emu_name_orig_text : String = n_emu_name.text
 
 func _enter_tree():
 	low_cpu_mode_orig = OS.low_processor_usage_mode
@@ -19,10 +26,34 @@ func _exit_tree():
 	OS.low_processor_usage_mode = low_cpu_mode_orig
 	OS.low_processor_usage_mode_sleep_usec = low_cpu_mode_sleep_orig
 
-func _ready():
-	label_text = $Label.text
+func _notification(what):
+	match what:
+		NOTIFICATION_WM_FOCUS_IN:
+			# 30 FPS
+			OS.low_processor_usage_mode_sleep_usec = 1000000 / 30
+		NOTIFICATION_WM_FOCUS_OUT:
+			# 10 FPS
+			OS.low_processor_usage_mode_sleep_usec = 1000000 / 10
+			n_timer.stop()
 
-func set_game_data(_game_data : RetroHubGameData):
-	game_data = _game_data
+func _process(delta):
+	if n_timer.is_stopped():
+		n_kill_press_progress.value = 0
+	else:
+		n_kill_press_progress.value = n_timer.wait_time - n_timer.time_left
 
-	$Label.text = label_text % game_data.name
+func _input(event):
+	if OS.is_window_focused():
+		if event.is_action_released("rh_menu"):
+			n_timer.stop()
+		if event.is_action_pressed("rh_menu"):
+			n_timer.start()
+
+func set_info(logo_path: String, game_name: String, emu_name: String):
+	n_emu_logo.texture = load(logo_path)
+	n_game_name.text = game_name_orig_text % game_name
+	n_emu_name.text = emu_name_orig_text % emu_name
+
+
+func _on_Timer_timeout():
+	RetroHub.kill_game_process()

--- a/scenes/game_launched/GameLaunched.tscn
+++ b/scenes/game_launched/GameLaunched.tscn
@@ -1,19 +1,122 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://scenes/game_launched/GameLaunched.gd" type="Script" id=1]
+[ext_resource path="res://assets/emulators/cemu.png" type="Texture" id=2]
+[ext_resource path="res://addons/controller_icons/objects/TextureRect.gd" type="Script" id=3]
+[ext_resource path="res://resources/fonts/default_bold.tres" type="DynamicFont" id=4]
+[ext_resource path="res://resources/fonts/default_italic.tres" type="DynamicFont" id=5]
+[ext_resource path="res://addons/controller_icons/assets/key/esc.png" type="Texture" id=7]
+[ext_resource path="res://assets/icons/controller_mapper/circle_progress.png" type="Texture" id=8]
 
-[node name="CenterContainer" type="CenterContainer"]
+[node name="CenterContainer" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource( 1 )
 
-[node name="Label" type="Label" parent="."]
-margin_left = 356.0
-margin_top = 264.0
-margin_right = 667.0
-margin_bottom = 312.0
-text = "Currently running %s
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -298.0
+margin_top = -133.0
+margin_right = 298.0
+margin_bottom = 133.0
 
-Close the game/emulator to wake RetroHub up..."
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+margin_right = 596.0
+margin_bottom = 96.0
+size_flags_horizontal = 3
+custom_constants/separation = 10
+
+[node name="EmuLogo" type="TextureRect" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+margin_right = 96.0
+margin_bottom = 96.0
+rect_min_size = Vector2( 96, 96 )
+texture = ExtResource( 2 )
+expand = true
+stretch_mode = 6
+
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer"]
+margin_left = 106.0
+margin_right = 596.0
+margin_bottom = 96.0
+size_flags_horizontal = 3
+
+[node name="GameName" type="Label" parent="VBoxContainer/HBoxContainer/VBoxContainer"]
+unique_name_in_owner = true
+margin_right = 490.0
+margin_bottom = 46.0
+size_flags_horizontal = 3
+size_flags_vertical = 7
+custom_fonts/font = ExtResource( 4 )
+text = "%s"
+autowrap = true
+clip_text = true
+
+[node name="EmuName" type="Label" parent="VBoxContainer/HBoxContainer/VBoxContainer"]
+unique_name_in_owner = true
+margin_top = 50.0
+margin_right = 490.0
+margin_bottom = 96.0
+size_flags_horizontal = 3
+size_flags_vertical = 7
+text = "Running on %s"
+autowrap = true
+clip_text = true
+
+[node name="Label" type="Label" parent="VBoxContainer"]
+margin_top = 202.0
+margin_right = 596.0
+margin_bottom = 222.0
+size_flags_vertical = 14
+custom_fonts/font = ExtResource( 5 )
+text = "(remember to save your game progress before closing the emulator manually!)"
 align = 1
 valign = 1
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 226.0
+margin_right = 596.0
+margin_bottom = 266.0
+custom_constants/separation = 10
+
+[node name="ControllerTextureRect" type="TextureRect" parent="VBoxContainer/HBoxContainer2"]
+margin_right = 40.0
+margin_bottom = 40.0
+rect_min_size = Vector2( 40, 40 )
+texture = ExtResource( 7 )
+expand = true
+script = ExtResource( 3 )
+path = "rh_menu"
+
+[node name="KillPressProgress" type="TextureProgress" parent="VBoxContainer/HBoxContainer2/ControllerTextureRect"]
+unique_name_in_owner = true
+show_behind_parent = true
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -23.0
+margin_top = -24.0
+margin_right = 23.0
+margin_bottom = 24.0
+max_value = 1.9
+step = 0.01
+texture_progress = ExtResource( 8 )
+fill_mode = 4
+nine_patch_stretch = true
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer2"]
+margin_left = 50.0
+margin_top = 13.0
+margin_right = 186.0
+margin_bottom = 27.0
+text = "Kill emulator process"
+
+[node name="Timer" type="Timer" parent="."]
+unique_name_in_owner = true
+wait_time = 2.0
+
+[connection signal="timeout" from="Timer" to="." method="_on_Timer_timeout"]

--- a/scenes/root/Root.gd
+++ b/scenes/root/Root.gd
@@ -6,6 +6,7 @@ onready var n_viewport : Viewport = $ViewportContainer/Viewport
 onready var n_config_popup : Popup = $ConfigPopup
 onready var n_filesystem_popup : Popup = $FileSystemPopup
 onready var n_keyboard_popup := $"%Keyboard"
+onready var n_warning_popup := $"%WarningPopup"
 
 onready var popup_nodes := [
 	n_config_popup,
@@ -29,6 +30,8 @@ func _ready():
 	# Add popups to UI singleton
 	RetroHubUI._n_filesystem_popup = n_filesystem_popup
 	RetroHubUI._n_virtual_keyboard = n_keyboard_popup
+	RetroHubUI._n_config_popup = n_config_popup
+	RetroHubUI._n_warning_popup = n_warning_popup
 
 	# Handle viewport changes
 	#warning-ignore:return_value_discarded
@@ -94,7 +97,10 @@ func _on_theme_loaded(theme_data: RetroHubTheme):
 func _on_game_loaded(game_data: RetroHubGameData):
 	var game_launched_child : Node = load("res://scenes/game_launched/GameLaunched.tscn").instance()
 	n_viewport.set_theme(game_launched_child)
-	game_launched_child.game_data = game_data
+	game_launched_child.set_info(
+		"res://assets/emulators/%s.png" % RetroHub.launched_emulator["name"],
+		game_data.name,
+		RetroHub.launched_emulator["fullname"])
 	print("Loaded game")
 
 func set_theme_input_enabled(enabled : bool):

--- a/scenes/root/Root.tscn
+++ b/scenes/root/Root.tscn
@@ -68,6 +68,32 @@ access = 2
 show_hidden_files = true
 script = ExtResource( 6 )
 
+[node name="WarningPopup" type="AcceptDialog" parent="."]
+unique_name_in_owner = true
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -304.0
+margin_top = -173.0
+margin_right = 304.0
+margin_bottom = 173.0
+theme = ExtResource( 5 )
+
+[node name="WarningLabel" type="Label" parent="WarningPopup"]
+unique_name_in_owner = true
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 8.0
+margin_top = 8.0
+margin_right = -8.0
+margin_bottom = -44.0
+text = "
+"
+align = 1
+valign = 1
+autowrap = true
+
 [node name="Keyboard" type="PopupPanel" parent="."]
 unique_name_in_owner = true
 anchor_right = 1.0

--- a/source/UI.gd
+++ b/source/UI.gd
@@ -2,6 +2,8 @@ extends Node
 
 var _n_filesystem_popup : FileDialog setget _set_filesystem_popup
 var _n_virtual_keyboard : PopupPanel setget _set_virtual_keyboard
+var _n_config_popup : Popup setget _set_config_popup
+var _n_warning_popup : AcceptDialog setget _set_warning_popup
 
 var color_theme_accent := Color("ffbb89")
 
@@ -27,6 +29,19 @@ enum Icons {
 	WARNING
 }
 
+enum ConfigTabs {
+	QUIT,
+	GAME,
+	SCRAPER,
+	THEME,
+	SETTINGS_GENERAL,
+	SETTINGS_INPUT,
+	SETTINGS_REGION,
+	SETTINGS_SYSTEMS,
+	SETTINGS_EMULATORS,
+	SETTINGS_ABOUT
+}
+
 signal path_selected(file)
 
 func _set_filesystem_popup(popup: FileDialog):
@@ -40,6 +55,12 @@ func _set_filesystem_popup(popup: FileDialog):
 
 func _set_virtual_keyboard(keyboard: PopupPanel):
 	_n_virtual_keyboard = keyboard
+
+func _set_config_popup(config_popup: Popup):
+	_n_config_popup = config_popup
+
+func _set_warning_popup(warning_popup: AcceptDialog):
+	_n_warning_popup = warning_popup
 
 func _on_popup_selected(file: String):
 	emit_signal("path_selected", file)
@@ -75,3 +96,19 @@ func is_event_from_virtual_keyboard() -> bool:
 
 func hide_virtual_keyboard() -> void:
 	_n_virtual_keyboard.hide()
+
+func open_app_config(tab: int = -1):
+	if _n_config_popup:
+		if tab != -1:
+			tab = int(clamp(tab, 0, _n_config_popup.n_tab_buttons.size()))
+			_n_config_popup.n_tab_buttons[tab].grab_focus()
+			_n_config_popup.n_tab_buttons[tab].pressed = true
+			_n_config_popup._on_Tab_pressed(tab)
+		_n_config_popup.popup()
+
+func show_warning(text: String):
+	if _n_warning_popup:
+		_n_warning_popup.get_node("%WarningLabel").text = text
+		_n_warning_popup.popup_centered()
+		yield(get_tree(), "idle_frame")
+		_n_warning_popup.get_ok().grab_focus()


### PR DESCRIPTION
Depends on #206
Closes #198

Adds a warning when no valid emulator configuration was found, prompting users to configure it:
![image](https://user-images.githubusercontent.com/6501975/224848135-1fbac7cf-6e06-4b5e-a6ff-ae14dd5a599d.png)
Also changed the launched game to a more useful window, with functionality to kill the game process as well:
![image](https://user-images.githubusercontent.com/6501975/224848207-bdbfc257-03f0-4481-baf4-d91ab59f82df.png)
