### PR TITLE
Fix app crash with slow-processing themes

### DIFF
--- a/source/Config.gd
+++ b/source/Config.gd
@@ -424,7 +424,7 @@ func unload_theme():
 		save_theme_config()
 
 		if is_instance_valid(theme_data.entry_scene):
-			theme_data.entry_scene.free()
+			theme_data.entry_scene.queue_free()
 
 		theme_data = null
 		if !ProjectSettings.unload_resource_pack(theme_path):


### PR DESCRIPTION
`queue_free()` apparently can be called even when references to the original scene are lost. This solves a crash that may be caused by "slow" themes that are still processing input events when being forcibly freed. 