### PR TITLE
Use available threads on ScreenScraper

### DIFF
--- a/scenes/config/ScreenScrapperSettings.gd
+++ b/scenes/config/ScreenScrapperSettings.gd
@@ -3,6 +3,9 @@ extends VBoxContainer
 onready var n_use_account := $"%UseAccount"
 onready var n_username := $"%Username"
 onready var n_password := $"%Password"
+onready var n_thread_count_lbl := $"%ThreadCountLabel"
+onready var n_thread_count := $"%ThreadCount"
+
 
 var changed := false
 
@@ -17,7 +20,8 @@ func _on_config_ready(config_data: ConfigData):
 	n_password.editable = config_data.scraper_ss_use_custom_account
 	n_username.text = RetroHubConfig._get_credential("scraper_ss_username")
 	n_password.text = RetroHubConfig._get_credential("scraper_ss_password")
-
+	n_thread_count.value = thread_count_to_range(config_data.scraper_ss_max_threads)
+	update_thread_count_label(config_data.scraper_ss_max_threads)
 
 func _on_text_changed(_new_text):
 	changed = true
@@ -38,3 +42,24 @@ func save_credentials():
 		RetroHubConfig._set_credential("scraper_ss_username", n_username.text)
 		RetroHubConfig._set_credential("scraper_ss_password", n_password.text)
 		changed = false
+
+func _on_ThreadCount_value_changed(value: float):
+	var value_i := thread_count_from_range()
+	update_thread_count_label(value_i)
+	RetroHubConfig.config.scraper_ss_max_threads = value_i
+
+func thread_count_to_range(value: int) -> int:
+	if value == 0:
+		return 11
+	return value
+
+func thread_count_from_range() -> int:
+	if n_thread_count.value >= 11:
+		return 0
+	return int(n_thread_count.value)
+
+func update_thread_count_label(value: int):
+	if value == 0:
+		n_thread_count_lbl.text = "Unlimited"
+	else:
+		n_thread_count_lbl.text = str(value)

--- a/scenes/config/ScreenScrapperSettings.tscn
+++ b/scenes/config/ScreenScrapperSettings.tscn
@@ -146,7 +146,41 @@ text = " Warning: Due to the way ScreenScraper works, the password will be store
 fit_content_height = true
 scroll_active = false
 
+[node name="HBoxContainer5" type="HBoxContainer" parent="."]
+margin_top = 176.0
+margin_right = 1024.0
+margin_bottom = 206.0
+size_flags_horizontal = 3
+
+[node name="Label" type="Label" parent="HBoxContainer5"]
+margin_top = 8.0
+margin_right = 708.0
+margin_bottom = 22.0
+size_flags_horizontal = 3
+text = "Scraper maximum thread count:"
+
+[node name="ThreadCountLabel" type="Label" parent="HBoxContainer5"]
+unique_name_in_owner = true
+margin_left = 712.0
+margin_top = 8.0
+margin_right = 720.0
+margin_bottom = 22.0
+text = "1"
+
+[node name="ThreadCount" type="HSlider" parent="HBoxContainer5"]
+unique_name_in_owner = true
+margin_left = 724.0
+margin_right = 1024.0
+margin_bottom = 30.0
+rect_min_size = Vector2( 300, 30 )
+min_value = 2.0
+max_value = 11.0
+value = 2.0
+tick_count = 10
+ticks_on_borders = true
+
 [connection signal="toggled" from="HBoxContainer/UseAccount" to="." method="_on_UseAccount_toggled"]
 [connection signal="text_changed" from="HBoxContainer2/Username" to="." method="_on_text_changed"]
 [connection signal="toggled" from="HBoxContainer3/ShowPassword" to="." method="_on_ShowPassword_toggled"]
 [connection signal="text_changed" from="HBoxContainer3/Password" to="." method="_on_text_changed"]
+[connection signal="value_changed" from="HBoxContainer5/ThreadCount" to="." method="_on_ThreadCount_value_changed"]

--- a/scenes/popups/scraper/ScraperPopup.gd
+++ b/scenes/popups/scraper/ScraperPopup.gd
@@ -8,6 +8,7 @@ onready var n_scraper_done := $"%ScraperDone"
 onready var n_scraper_warning := $"%ScraperWarning"
 onready var n_scraper_error := $"%ScraperError"
 onready var n_scraper_pending := $"%ScraperPending"
+onready var n_scraper_details := $"%ScraperDetails"
 
 onready var n_game_entries := $"%GameEntries"
 onready var n_game_entry_editor := $"%GameEntryEditor"
@@ -129,6 +130,7 @@ func add_media_request(game_entry: RetroHubScraperGameEntry, priority: bool = fa
 
 
 func thread_fetch_game_entries():
+	scraper.connect("scraper_details", self, "t_on_scraper_details")
 	#warning-ignore:return_value_discarded
 	scraper.connect("game_scrape_finished", self, "t_on_game_scrape_finished")
 	#warning-ignore:return_value_discarded
@@ -197,6 +199,7 @@ func thread_fetch_game_entries():
 					requests_curr.erase(req)
 					game_entry.curr += 1
 
+	scraper.disconnect("scraper_details", self, "t_on_scraper_details")
 	scraper.disconnect("game_scrape_finished", self, "t_on_game_scrape_finished")
 	scraper.disconnect("game_scrape_multiple_available", self, "t_on_game_scrape_multiple_available")
 	scraper.disconnect("game_scrape_not_found", self, "t_on_game_scrape_not_found")
@@ -213,6 +216,9 @@ func _ensure_valid_req(game_data: RetroHubGameData):
 		return null
 	else:
 		return pending_datas[game_data]
+
+func t_on_scraper_details(text: String):
+	n_scraper_details.set_deferred("text", text)
 
 func t_on_game_scrape_finished(game_data: RetroHubGameData):
 	var req : Request = _ensure_valid_req(game_data)

--- a/scenes/popups/scraper/ScraperPopup.tscn
+++ b/scenes/popups/scraper/ScraperPopup.tscn
@@ -19,6 +19,7 @@
 [ext_resource path="res://scenes/popups/scraper/GameEntries.gd" type="Script" id=17]
 
 [node name="ScraperPopup" type="PopupPanel"]
+visible = true
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 1.0
@@ -105,6 +106,20 @@ margin_top = 5.0
 margin_right = 156.0
 margin_bottom = 19.0
 text = "0"
+
+[node name="VSeparator" type="VSeparator" parent="VBoxContainer/HBoxContainer"]
+margin_left = 160.0
+margin_right = 164.0
+margin_bottom = 24.0
+
+[node name="ScraperDetails" type="Label" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+margin_left = 168.0
+margin_top = 5.0
+margin_right = 1016.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+clip_text = true
 
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
 margin_top = 28.0

--- a/source/data/ConfigData.gd
+++ b/source/data/ConfigData.gd
@@ -20,6 +20,7 @@ var date_format : String = "mm/dd/yyyy" setget _set_date_format
 var system_names : Dictionary = default_system_names() setget _set_system_names
 var scraper_hash_file_size : int = 64 setget _set_scraper_hash_file_size
 var scraper_ss_use_custom_account : bool = false setget _set_scraper_ss_use_custom_account
+var scraper_ss_max_threads : int = 6 setget _set_scraper_ss_max_threads
 var custom_input_remap : String = "" setget _set_custom_input_remap
 var input_key_map : Dictionary = default_input_key_map() setget _set_input_key_map
 var input_controller_map : Dictionary = default_input_controller_map() setget _set_input_controller_map
@@ -45,6 +46,7 @@ const KEY_DATE_FORMAT = "date_format"
 const KEY_SYSTEM_NAMES = "system_names"
 const KEY_SCRAPER_HASH_FILE_SIZE = "scraper_hash_file_size"
 const KEY_SCRAPER_SS_USE_CUSTOM_ACCOUNT = "scraper_ss_use_custom_account"
+const KEY_SCRAPER_SS_MAX_THREADS = "scraper_ss_max_threads"
 const KEY_CUSTOM_INPUT_REMAP = "custom_input_remap"
 const KEY_INPUT_KEY_MAP = "input_key_map"
 const KEY_INPUT_CONTROLLER_MAP = "input_controller_map"
@@ -72,6 +74,7 @@ const _keys = [
 	KEY_SYSTEM_NAMES,
 	KEY_SCRAPER_HASH_FILE_SIZE,
 	KEY_SCRAPER_SS_USE_CUSTOM_ACCOUNT,
+	KEY_SCRAPER_SS_MAX_THREADS,
 	KEY_CUSTOM_INPUT_REMAP,
 	KEY_INPUT_KEY_MAP,
 	KEY_INPUT_CONTROLLER_MAP,
@@ -203,6 +206,10 @@ func _set_scraper_hash_file_size(_scraper_hash_file_size):
 func _set_scraper_ss_use_custom_account(_scraper_ss_use_custom_account):
 	mark_for_saving()
 	scraper_ss_use_custom_account = _scraper_ss_use_custom_account
+
+func _set_scraper_ss_max_threads(_scraper_ss_max_threads):
+	mark_for_saving()
+	scraper_ss_max_threads = _scraper_ss_max_threads
 
 func _set_custom_input_remap(_custom_input_remap):
 	mark_for_saving()

--- a/source/scraper/Scraper.gd
+++ b/source/scraper/Scraper.gd
@@ -1,6 +1,10 @@
 extends Node
 class_name RetroHubScraper
 
+# Signal to share any details specific to this scraper. Use this to
+# display some important information to the user regarding the scraper.
+#warning-ignore:unused_signal
+signal scraper_details(text)
 # Signals that a game scrape has finished successfully, returning the
 # modified game data.
 #warning-ignore:unused_signal


### PR DESCRIPTION
Detects available threads on user accounts to use them.
![image](https://user-images.githubusercontent.com/6501975/225413989-a83f516a-afd3-447f-b109-fa47dfdd61fd.png)
Also added a limit so users can limit the thread usage on slow networks (can be set to unlimited)
![image](https://user-images.githubusercontent.com/6501975/225414112-3e11d195-8d7d-4617-83a0-8e11d325b5d9.png)
Closes #205 