### PR TITLE
Make screen reader toggeable and added it to initial setup

### DIFF
--- a/addons/godot-accessibility/Accessible.gd
+++ b/addons/godot-accessibility/Accessible.gd
@@ -63,9 +63,9 @@ func _accept_dialog_speak():
 			if c is Label:
 				text = c.text
 	if text:
-		TTS.speak("Dialog: %s" % text, false)
+		TTS.speak("Dialog: %s" % text)
 	else:
-		TTS.speak("Dialog", false)
+		TTS.speak("Dialog")
 
 
 func _accept_dialog_focused():
@@ -76,15 +76,21 @@ func _accept_dialog_focused():
 
 
 func _accept_dialog_about_to_show():
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	_accept_dialog_speak()
 	#ScreenReader.should_stop_on_focus = false
 
 
 func _basebutton_button_down():
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	TTS.stop()
 
 
 func checkbox_focused():
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	var tokens = PoolStringArray([])
 	if node.text:
 		tokens.append(node.text)
@@ -93,10 +99,12 @@ func checkbox_focused():
 	else:
 		tokens.append("unchecked")
 	tokens.append(" checkbox")
-	TTS.speak(tokens.join(" "), false)
+	TTS.speak(tokens.join(" "))
 
 
 func _checkbox_or_checkbutton_toggled(checked):
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	if node.has_focus():
 		if checked:
 			TTS.speak("checked", true)
@@ -105,6 +113,8 @@ func _checkbox_or_checkbutton_toggled(checked):
 
 
 func _checkbutton_focused():
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	var tokens = PoolStringArray([])
 	if node.text:
 		tokens.append(node.text)
@@ -113,13 +123,15 @@ func _checkbutton_focused():
 	else:
 		tokens.append("unchecked")
 	tokens.append(" check button")
-	TTS.speak(tokens.join(" "), false)
+	TTS.speak(tokens.join(" "))
 
 
 var spoke_hint_tooltip
 
 
 func _button_focused():
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	var tokens = PoolStringArray([])
 	if node.text:
 		tokens.append(node.text)
@@ -131,7 +143,7 @@ func _button_focused():
 	tokens.append("button")
 	if node.disabled:
 		tokens.append("disabled")
-	TTS.speak(tokens.join(": "), false)
+	TTS.speak(tokens.join(": "))
 
 
 func try_to_get_text_in_theme(theme, texture):
@@ -160,6 +172,8 @@ func _get_graphical_button_text(texture):
 
 
 func _texturebutton_focused():
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	var tokens = PoolStringArray([])
 	tokens.append(_get_graphical_button_text(node.texture_normal))
 	tokens.append("button")
@@ -167,6 +181,8 @@ func _texturebutton_focused():
 
 
 func item_list_item_focused(idx):
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	var tokens = PoolStringArray([])
 	var text = node.get_item_text(idx)
 	if text:
@@ -179,12 +195,14 @@ func item_list_item_focused(idx):
 
 
 func item_list_focused():
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	var count = node.get_item_count()
 	var selected = node.get_selected_items()
 	print_debug(selected)
 	if len(selected) == 0:
 		if node.get_item_count() == 0:
-			return TTS.speak("list, 0 items", false)
+			return TTS.speak("list, 0 items")
 		selected = 0
 		node.select(selected)
 		node.emit_signal("item_list_item_selected", selected)
@@ -195,18 +213,26 @@ func item_list_focused():
 
 
 func item_list_item_selected(index):
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	item_list_item_focused(index)
 
 
 func item_list_multi_selected(index, selected):
-	TTS.speak("Multiselect", false)
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
+	TTS.speak("Multiselect")
 
 
 func item_list_nothing_selected():
-	TTS.speak("Nothing selected", true)
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
+	TTS.speak("Nothing selected")
 
 
 func item_list_input(event):
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	if event.is_action_pressed("ui_right") or event.is_action_pressed("ui_left"):
 		return node.accept_event()
 	var old_count = node.get_item_count()
@@ -244,7 +270,7 @@ func _label_focused():
 	if text == "":
 		text = "blank"
 	tokens.append(text)
-	TTS.speak(tokens.join(": "), false)
+	TTS.speak(tokens.join(": "))
 
 
 func line_edit_focused():
@@ -258,7 +284,7 @@ func line_edit_focused():
 	var type = "editable text"
 	if not node.editable:
 		type = "text"
-	TTS.speak("%s: %s" % [text, type], false)
+	TTS.speak("%s: %s" % [text, type])
 
 
 var old_text = ""
@@ -267,6 +293,8 @@ var old_pos
 
 
 func line_edit_text_changed(text):
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	if text == null or old_text == null:
 		return
 	if len(text) > len(old_text):
@@ -304,14 +332,16 @@ func menu_button_focused():
 		tokens.append(node.hint_tooltip)
 		spoke_hint_tooltip = true
 	tokens.append("menu")
-	TTS.speak(tokens.join(": "), false)
+	TTS.speak(tokens.join(": "))
 
 
 func popup_menu_focused():
-	TTS.speak("menu", false)
+	TTS.speak("menu")
 
 
 func popup_menu_item_id_focused(index):
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	print_debug("item id focus %s" % index)
 	var tokens = PoolStringArray([])
 	var shortcut = node.get_item_shortcut(index)
@@ -346,6 +376,8 @@ func popup_menu_item_id_focused(index):
 
 
 func popup_menu_item_id_pressed(index):
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	if node.is_item_checkable(index):
 		if node.is_item_checked(index):
 			TTS.speak("checked", true)
@@ -368,10 +400,12 @@ func range_focused():
 	tokens.append("maximum %s" % node.max_value)
 	if OS.has_touchscreen_ui_hint():
 		tokens.append("Swipe up and down to change.")
-	TTS.speak(tokens.join(": "), false)
+	TTS.speak(tokens.join(": "))
 
 
 func range_value_changed(value):
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	if node.has_focus():
 		TTS.speak("%s" % value, true)
 
@@ -386,7 +420,7 @@ func text_edit_focus():
 		tokens.append("read-only edit text")
 	else:
 		tokens.append("edit text")
-	TTS.speak(tokens.join(": "), false)
+	TTS.speak(tokens.join(": "))
 
 
 func text_edit_input(event):
@@ -451,11 +485,15 @@ var prev_selected_cell
 
 
 func _tree_item_or_cell_selected():
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	button_index = null
 	_tree_item_render()
 
 
 func tree_item_multi_selected(item, column, selected):
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	if selected:
 		TTS.speak("selected", true)
 	else:
@@ -520,6 +558,8 @@ var _was_collapsed
 
 
 func _tree_item_collapsed(item):
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	if node.has_focus():
 		var selected = false
 		for column in range(node.columns):
@@ -536,8 +576,8 @@ func _tree_item_collapsed(item):
 
 func progress_bar_focused():
 	var percentage = int(node.ratio * 100)
-	TTS.speak("%s percent" % percentage, false)
-	TTS.speak("progress bar", false)
+	TTS.speak("%s percent" % percentage)
+	TTS.speak("progress bar")
 
 
 var last_percentage_spoken
@@ -546,6 +586,8 @@ var last_percentage_spoken_at = 0
 
 
 func progress_bar_value_changed(value):
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	var percentage = node.value / (node.max_value - node.min_value) * 100
 	percentage = int(percentage)
 	if (
@@ -560,10 +602,12 @@ func progress_bar_value_changed(value):
 func tab_container_focused():
 	var text = node.get_tab_title(node.current_tab)
 	text += ": tab: " + str(node.current_tab + 1) + " of " + str(node.get_tab_count())
-	TTS.speak(text, false)
+	TTS.speak(text)
 
 
 func tab_container_tab_changed(tab):
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	if node.has_focus():
 		TTS.stop()
 		tab_container_focused()
@@ -586,15 +630,16 @@ func tab_container_input(event):
 
 
 func focused():
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	print_debug("Focus: %s" % node)
-	TTS.stop()
 	if not node is Label:
 		var label = _guess_label()
 		if label:
 			if label is Label:
 				label = label.text
 			if label and label != "":
-				TTS.speak(label, false)
+				TTS.speak(label)
 	# Check if any node implements a custom TTS message
 	var n : Node = node
 	while n:
@@ -642,15 +687,19 @@ func focused():
 		#TTS.speak(node.get_class(), true)
 		print_debug("No handler")
 	if node.hint_tooltip and not spoke_hint_tooltip:
-		TTS.speak(node.hint_tooltip, false)
+		TTS.speak(node.hint_tooltip)
 	spoke_hint_tooltip = false
 
 
 func unfocused():
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	position_in_children = 0
 
 
 func click_focused():
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	if node.has_focus():
 		return
 	if node.focus_mode == Control.FOCUS_ALL:
@@ -658,13 +707,15 @@ func click_focused():
 
 
 func gui_input(event):
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return
 	if (
 		event is InputEventKey
 		and Input.is_action_just_pressed("ui_accept")
 		and event.control
 		and event.alt
 	):
-		TTS.speak("click", false)
+		TTS.speak("click")
 		click()
 	elif event is InputEventKey and event.pressed and not event.echo and event.scancode == KEY_MENU:
 		node.get_tree().root.warp_mouse(node.rect_global_position)
@@ -727,7 +778,7 @@ func editor_inspector_section_focused():
 			tokens.append("expanded")
 		else:
 			tokens.append("collapsed")
-	TTS.speak(tokens.join(": "), false)
+	TTS.speak(tokens.join(": "))
 
 
 func editor_inspector_section_input(event):
@@ -751,9 +802,6 @@ func _init(node):
 	self.node = node
 	#if _is_focusable(node):
 	#	node.set_focus_mode(Control.FOCUS_ALL)
-	var label = _guess_label()
-	if label and label is Label:
-		label.set_focus_mode(Control.FOCUS_NONE)
 	node.connect("focus_entered", self, "focused")
 	node.connect("mouse_entered", self, "click_focused")
 	node.connect("focus_exited", self, "unfocused")

--- a/addons/godot-tts/TTS.gd
+++ b/addons/godot-tts/TTS.gd
@@ -20,7 +20,7 @@ func _init():
 		tts = Engine.get_singleton("TTS")
 	else:
 		TTS = preload("godot-tts.gdns")
-	if TTS and (TTS.can_instance() or Engine.editor_hint):
+	if TTS and (TTS.can_instance() or Engine.editor_hint) and RetroHubConfig.config.accessibility_screen_reader_enabled:
 		tts = TTS.new()
 	if tts:
 		if not tts is JNISingleton:
@@ -127,6 +127,8 @@ var normal_rate_percentage setget , _get_rate_percentage
 
 
 func speak(text, interrupt := true):
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		return ""
 	var utterance
 	if tts != null:
 		utterance = tts.speak(text, interrupt)

--- a/scenes/config/settings/GeneralSettings.gd
+++ b/scenes/config/settings/GeneralSettings.gd
@@ -10,6 +10,7 @@ onready var n_graphics_mode := $"%GraphicsMode"
 onready var n_vsync := $"%VSync"
 onready var n_render_res_label := $"%RenderResLabel"
 onready var n_render_res := $"%RenderRes"
+onready var n_screen_reader := $"%ScreenReader"
 
 var theme_id_map := {}
 
@@ -68,6 +69,7 @@ func _on_config_ready(config_data: ConfigData):
 	n_vsync.set_pressed_no_signal(config_data.vsync)
 	n_render_res.value = config_data.render_resolution
 	set_language(config_data.lang)
+	n_screen_reader.set_pressed_no_signal(config_data.accessibility_screen_reader_enabled)
 
 func _on_config_updated(key: String, _old_value, new_value):
 	match key:
@@ -109,6 +111,7 @@ func _on_AppSettings_visibility_changed():
 
 func _on_FirstTimeWizardWarning_confirmed():
 	RetroHubConfig.config.is_first_time = true
+	RetroHubConfig.config.accessibility_screen_reader_enabled = true
 	RetroHub.quit()
 
 
@@ -130,3 +133,7 @@ func _on_RenderRes_value_changed(value):
 	RetroHubConfig.config.render_resolution = value
 	n_render_res_label.text = str(value) + "%"
 
+
+func _on_ScreenReader_toggled(button_pressed):
+	RetroHubConfig.config.accessibility_screen_reader_enabled = button_pressed
+	RetroHubConfig.save_config()

--- a/scenes/config/settings/GeneralSettings.tscn
+++ b/scenes/config/settings/GeneralSettings.tscn
@@ -222,12 +222,49 @@ margin_left = 824.0
 margin_right = 1024.0
 margin_bottom = 16.0
 rect_min_size = Vector2( 200, 0 )
-focus_neighbour_bottom = NodePath("../../../User/HBoxContainer/SetGamePath")
+focus_neighbour_bottom = NodePath("../../../Accessibility/HBoxContainer/ScreenReader")
 min_value = 50.0
 step = 5.0
 value = 100.0
 tick_count = 11
 ticks_on_borders = true
+
+[node name="Accessibility" type="VBoxContainer" parent="ScrollContainer/VBoxContainer"]
+margin_top = 278.0
+margin_right = 1024.0
+margin_bottom = 350.0
+
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/Accessibility"]
+margin_right = 1024.0
+margin_bottom = 20.0
+custom_fonts/font = ExtResource( 2 )
+text = "Accessibility"
+
+[node name="HSeparator" type="HSeparator" parent="ScrollContainer/VBoxContainer/Accessibility"]
+margin_top = 24.0
+margin_right = 1024.0
+margin_bottom = 28.0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/Accessibility"]
+margin_top = 32.0
+margin_right = 1024.0
+margin_bottom = 72.0
+size_flags_horizontal = 3
+custom_constants/separation = 15
+
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/Accessibility/HBoxContainer"]
+margin_top = 13.0
+margin_right = 933.0
+margin_bottom = 27.0
+size_flags_horizontal = 3
+text = "Enable screen reader:"
+
+[node name="ScreenReader" type="CheckButton" parent="ScrollContainer/VBoxContainer/Accessibility/HBoxContainer"]
+unique_name_in_owner = true
+margin_left = 948.0
+margin_right = 1024.0
+margin_bottom = 40.0
+focus_neighbour_bottom = NodePath("../../../User/HBoxContainer/SetGamePath")
 
 [node name="ScrollHandler" type="Control" parent="ScrollContainer"]
 script = ExtResource( 4 )
@@ -272,4 +309,5 @@ autowrap = true
 [connection signal="toggled" from="ScrollContainer/VBoxContainer/Graphics/HBoxContainer2/VSync" to="." method="_on_VSync_toggled"]
 [connection signal="drag_ended" from="ScrollContainer/VBoxContainer/Graphics/HBoxContainer3/RenderRes" to="." method="_on_RenderRes_drag_ended"]
 [connection signal="value_changed" from="ScrollContainer/VBoxContainer/Graphics/HBoxContainer3/RenderRes" to="." method="_on_RenderRes_value_changed"]
+[connection signal="toggled" from="ScrollContainer/VBoxContainer/Accessibility/HBoxContainer/ScreenReader" to="." method="_on_ScreenReader_toggled"]
 [connection signal="confirmed" from="FirstTimeWizardWarning" to="." method="_on_FirstTimeWizardWarning_confirmed"]

--- a/scenes/popups/first_time/FirstTimePopups.gd
+++ b/scenes/popups/first_time/FirstTimePopups.gd
@@ -7,6 +7,7 @@ export(Color) var color_prev := Color(0.4, 0.8, 0.4, 1)
 onready var n_sidebar := $"%Sidebar"
 onready var n_main_content := $"%MainContent"
 onready var n_rstick_tip := $"%RStickTip"
+onready var n_screenreader := $"%ScreenReader"
 
 onready var num_sections := n_sidebar.get_child_count()
 

--- a/scenes/popups/first_time/FirstTimePopups.tscn
+++ b/scenes/popups/first_time/FirstTimePopups.tscn
@@ -279,6 +279,8 @@ size_flags_horizontal = 2
 text = "for scrolling information"
 
 [node name="ScreenReader" type="Node" parent="."]
+pause_mode = 2
+unique_name_in_owner = true
 script = ExtResource( 19 )
 
 [connection signal="about_to_show" from="." to="." method="_on_FirstTimePopup_about_to_show"]

--- a/scenes/popups/first_time/IntroductionSection.gd
+++ b/scenes/popups/first_time/IntroductionSection.gd
@@ -2,11 +2,28 @@ extends Control
 
 signal advance_section
 
+onready var n_label := $"%Label"
+onready var n_screen_reader := $"%ScreenReader"
 onready var n_next_button := $"%NextButton"
 
 func grab_focus():
+	TTS.speak("To enable the screen reader, press the Control key.")
+	RetroHubConfig.config.accessibility_screen_reader_enabled = false
 	n_next_button.grab_focus()
 
+func _input(event):
+	if event is InputEventKey and event.scancode == KEY_CONTROL:
+		n_screen_reader.pressed = true
+		n_label.grab_focus()
 
 func _on_NextButton_pressed():
 	emit_signal("advance_section")
+
+
+func _on_ScreenReader_toggled(button_pressed):
+	RetroHubConfig.config.accessibility_screen_reader_enabled = button_pressed
+
+
+func _on_Label_focus_entered():
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+		n_screen_reader.grab_focus()

--- a/scenes/popups/first_time/IntroductionSection.tscn
+++ b/scenes/popups/first_time/IntroductionSection.tscn
@@ -16,9 +16,8 @@ anchor_bottom = 1.0
 
 [node name="TextureRect" type="TextureRect" parent="VBoxContainer"]
 margin_left = 384.0
-margin_top = 18.0
 margin_right = 640.0
-margin_bottom = 274.0
+margin_bottom = 256.0
 rect_min_size = Vector2( 256, 256 )
 size_flags_horizontal = 4
 size_flags_vertical = 10
@@ -27,9 +26,13 @@ expand = true
 stretch_mode = 6
 
 [node name="Label" type="Label" parent="VBoxContainer"]
-margin_top = 278.0
+unique_name_in_owner = true
+margin_top = 260.0
 margin_right = 1024.0
-margin_bottom = 326.0
+margin_bottom = 308.0
+focus_neighbour_top = NodePath("../NextButton")
+focus_neighbour_bottom = NodePath("../ScreenReader")
+focus_mode = 2
 size_flags_vertical = 2
 text = "Welcome to RetroHub!
 
@@ -38,11 +41,27 @@ align = 1
 valign = 1
 autowrap = true
 
+[node name="ScreenReader" type="CheckButton" parent="VBoxContainer"]
+unique_name_in_owner = true
+margin_left = 402.0
+margin_top = 408.0
+margin_right = 622.0
+margin_bottom = 448.0
+focus_neighbour_top = NodePath("../Label")
+focus_neighbour_bottom = NodePath("../NextButton")
+size_flags_horizontal = 4
+size_flags_vertical = 2
+text = "Enable screen reader?"
+
 [node name="NextButton" type="Button" parent="VBoxContainer"]
 unique_name_in_owner = true
 margin_top = 556.0
 margin_right = 1024.0
 margin_bottom = 576.0
+focus_neighbour_top = NodePath("../ScreenReader")
+focus_neighbour_bottom = NodePath("../Label")
 text = "Let's Go!"
 
+[connection signal="focus_entered" from="VBoxContainer/Label" to="." method="_on_Label_focus_entered"]
+[connection signal="toggled" from="VBoxContainer/ScreenReader" to="." method="_on_ScreenReader_toggled"]
 [connection signal="pressed" from="VBoxContainer/NextButton" to="." method="_on_NextButton_pressed"]

--- a/source/data/ConfigData.gd
+++ b/source/data/ConfigData.gd
@@ -32,6 +32,7 @@ var input_controller_echo_delay: float = 0.15 setget _set_input_controller_echo_
 var virtual_keyboard_layout : String = "qwerty" setget _set_virtual_keyboard_layout
 var virtual_keyboard_show_on_controller : bool = true setget _set_virtual_keyboard_show_on_controller
 var virtual_keyboard_show_on_mouse : bool = false setget _set_virtual_keyboard_show_on_mouse
+var accessibility_screen_reader_enabled : bool = true setget _set_accessibility_screen_reader_enabled
 
 const KEY_IS_FIRST_TIME = "is_first_time"
 const KEY_GAMES_DIR = "games_dir"
@@ -58,6 +59,7 @@ const KEY_INPUT_CONTROLLER_ECHO_DELAY = "input_controller_echo_delay"
 const KEY_VIRTUAL_KEYBOARD_LAYOUT = "virtual_keyboard_layout"
 const KEY_VIRTUAL_KEYBOARD_SHOW_ON_CONTROLLER = "virtual_keyboard_show_on_controller"
 const KEY_VIRTUAL_KEYBOARD_SHOW_ON_MOUSE = "virtual_keyboard_show_on_mouse"
+const KEY_ACCESSIBILITY_SCREEN_READER_ENABLED = "accessibility_screen_reader_enabled"
 
 
 const _keys = [
@@ -85,7 +87,8 @@ const _keys = [
 	KEY_INPUT_CONTROLLER_ECHO_DELAY,
 	KEY_VIRTUAL_KEYBOARD_LAYOUT,
 	KEY_VIRTUAL_KEYBOARD_SHOW_ON_CONTROLLER,
-	KEY_VIRTUAL_KEYBOARD_SHOW_ON_MOUSE
+	KEY_VIRTUAL_KEYBOARD_SHOW_ON_MOUSE,
+	KEY_ACCESSIBILITY_SCREEN_READER_ENABLED
 ]
 
 var _should_save : bool = true
@@ -269,6 +272,10 @@ func _set_virtual_keyboard_show_on_mouse(_virtual_keyboard_show_on_mouse):
 	mark_for_saving()
 	virtual_keyboard_show_on_mouse = _virtual_keyboard_show_on_mouse
 
+func _set_accessibility_screen_reader_enabled(_accessibility_screen_reader_enabled):
+	mark_for_saving()
+	accessibility_screen_reader_enabled = _accessibility_screen_reader_enabled
+
 func mark_for_saving():
 	if _should_save:
 		_config_changed = true
@@ -298,6 +305,7 @@ func load_config_from_path(path: String) -> int:
 		if _old_config.has(key):
 			set(key, _old_config[key])
 		else:
+			process_new_change(key)
 			_config_changed = true
 	_should_save = true
 
@@ -337,6 +345,11 @@ func save_config_to_path(path: String, force_save: bool = false) -> int:
 
 	_old_config = dict.duplicate(true)
 	return OK
+
+func process_new_change(key: String):
+	match key:
+		KEY_ACCESSIBILITY_SCREEN_READER_ENABLED:
+			accessibility_screen_reader_enabled = is_first_time
 
 func process_raw_config_changes(config: Dictionary):
 	# Scraper credentials were moved to a dedicated file


### PR DESCRIPTION
Adresses #223, but not enough to close it.

The screen reader can be toggled on the settings now:
![image](https://user-images.githubusercontent.com/6501975/226181948-bfd02bd3-518d-4f37-8329-583118e03327.png)
Additionally, a text message is always spoken in the first-time wizard, so screen reader users can enable it with a key press. A toggle was added as well:
![image](https://user-images.githubusercontent.com/6501975/226181976-97753c14-f7ed-4879-a970-0cc82e5c8c1c.png)
