### PR TITLE
Support AccessibilityFocus nodes from themes

### DIFF
--- a/addons/godot-accessibility/ScreenReader.gd
+++ b/addons/godot-accessibility/ScreenReader.gd
@@ -687,7 +687,8 @@ func gui_focus_changed(_node: Control):
 
 
 func _input(event):
-	if not RetroHubConfig.config.accessibility_screen_reader_enabled:
+	if not RetroHubConfig.config.accessibility_screen_reader_enabled or \
+		not is_instance_valid(node):
 		return
 	if (
 		event is InputEventKey

--- a/scenes/root/Root.gd
+++ b/scenes/root/Root.gd
@@ -18,6 +18,13 @@ onready var viewport_orig_size := Vector2(1024, 576)
 var n_last_focused : Control
 var is_popup_open : bool = false
 
+var resources_remap := []
+
+func _enter_tree():
+	resources_remap.append_array([
+		load("res://scenes/ui_nodes/AccessibilityFocus.gd").take_over_path("res://addons/retrohub_theme_helper/ui/AccessibilityFocus.gd")
+	])
+
 func _ready():
 	closed_popup()
 	#warning-ignore:return_value_discarded

--- a/scenes/ui_nodes/AccessibilityFocus.gd
+++ b/scenes/ui_nodes/AccessibilityFocus.gd
@@ -42,6 +42,9 @@ func _ready():
 	RetroHubConfig.connect("config_ready", self, "_on_config_ready")
 	RetroHubConfig.connect("config_updated", self, "_on_config_updated")
 
+	if RetroHub.is_main_app():
+		_on_config_ready(RetroHubConfig.config)
+
 func _on_config_ready(config: ConfigData):
 	toggle_info(config.accessibility_screen_reader_enabled)
 

--- a/source/utils/RegionUtils.gd
+++ b/source/utils/RegionUtils.gd
@@ -64,7 +64,7 @@ func globalize_date_dict(date_dict: Dictionary):
 func localize_age_rating(age_rating_raw: String) -> Control:
 	var rating_idx := localize_age_rating_idx()
 	var rating_node : Control = preload("res://scenes/ui_nodes/AgeRatingTextureRect.tscn").instance()
-	rating_node.from_idx(age_rating_raw.get_slice("/", rating_idx), rating_idx)
+	rating_node.from_idx(int(age_rating_raw.get_slice("/", rating_idx)), rating_idx)
 	return rating_node
 
 func localize_age_rating_idx() -> int:


### PR DESCRIPTION
This overrides paths from the theme helper addon, thus supporting them from the main app. For now it's only for AccessibilityFocus nodes, but later on this will add support for other objects, such as AgeTextureRect and LazyTextureRect.