### PR TITLE
Credit godot-accessibility and godot-tts addons

### DIFF
--- a/assets/copyright/licenses/mit_godot-accessibility.txt
+++ b/assets/copyright/licenses/mit_godot-accessibility.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Nolan Darilek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/assets/copyright/licenses/mit_godot-tts.txt
+++ b/assets/copyright/licenses/mit_godot-tts.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Nolan Darilek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scenes/config/AboutSettings.tscn
+++ b/scenes/config/AboutSettings.tscn
@@ -184,7 +184,7 @@ margin_bottom = -5.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="TabContainerHandler/TabContainer/Libraries"]
 margin_right = 1014.0
-margin_bottom = 779.0
+margin_bottom = 1077.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -504,9 +504,117 @@ fit_content_height = true
 
 [node name="AccessibilityFocus" type="Node" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/OnScreenKeyboard/RichTextLabel"]
 script = ExtResource( 18 )
-next = NodePath("../../../../../..")
 
 [node name="HSeparator" type="HSeparator" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/OnScreenKeyboard"]
+margin_top = 141.0
+margin_right = 1002.0
+margin_bottom = 145.0
+
+[node name="godot-accessibility" type="VBoxContainer" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer"]
+margin_top = 783.0
+margin_right = 1002.0
+margin_bottom = 928.0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-accessibility"]
+margin_right = 1002.0
+margin_bottom = 104.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-accessibility/HBoxContainer"]
+margin_right = 1002.0
+margin_bottom = 104.0
+size_flags_horizontal = 3
+
+[node name="Label" type="Label" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-accessibility/HBoxContainer/VBoxContainer"]
+margin_right = 1002.0
+margin_bottom = 50.0
+custom_fonts/font = ExtResource( 5 )
+text = "Godot Accessibility Plugin"
+
+[node name="AccessibilityFocus" type="Node" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-accessibility/HBoxContainer/VBoxContainer/Label"]
+script = ExtResource( 18 )
+
+[node name="RichTextLabel" type="RichTextLabel" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-accessibility/HBoxContainer/VBoxContainer"]
+margin_top = 54.0
+margin_right = 1002.0
+margin_bottom = 104.0
+bbcode_enabled = true
+bbcode_text = "Website: [url=https://github.com/lightsoutgames/godot-accessibility]https://github.com/lightsoutgames/godot-accessibility[/url]
+License: [url=mit_godot-accessibility]MIT[/url]"
+text = "Website: https://github.com/lightsoutgames/godot-accessibility
+License: MIT"
+fit_content_height = true
+
+[node name="AccessibilityFocus" type="Node" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-accessibility/HBoxContainer/VBoxContainer/RichTextLabel"]
+script = ExtResource( 18 )
+
+[node name="RichTextLabel" type="RichTextLabel" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-accessibility"]
+margin_top = 108.0
+margin_right = 1002.0
+margin_bottom = 137.0
+bbcode_enabled = true
+bbcode_text = "Addon to make default Godot UI nodes accessible to screen readers."
+text = "Addon to make default Godot UI nodes accessible to screen readers."
+fit_content_height = true
+
+[node name="AccessibilityFocus" type="Node" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-accessibility/RichTextLabel"]
+script = ExtResource( 18 )
+
+[node name="HSeparator" type="HSeparator" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-accessibility"]
+margin_top = 141.0
+margin_right = 1002.0
+margin_bottom = 145.0
+
+[node name="godot-tts" type="VBoxContainer" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer"]
+margin_top = 932.0
+margin_right = 1002.0
+margin_bottom = 1077.0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-tts"]
+margin_right = 1002.0
+margin_bottom = 104.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-tts/HBoxContainer"]
+margin_right = 1002.0
+margin_bottom = 104.0
+size_flags_horizontal = 3
+
+[node name="Label" type="Label" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-tts/HBoxContainer/VBoxContainer"]
+margin_right = 1002.0
+margin_bottom = 50.0
+custom_fonts/font = ExtResource( 5 )
+text = "Godot TTS"
+
+[node name="AccessibilityFocus" type="Node" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-tts/HBoxContainer/VBoxContainer/Label"]
+script = ExtResource( 18 )
+
+[node name="RichTextLabel" type="RichTextLabel" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-tts/HBoxContainer/VBoxContainer"]
+margin_top = 54.0
+margin_right = 1002.0
+margin_bottom = 104.0
+bbcode_enabled = true
+bbcode_text = "Website: [url=https://github.com/lightsoutgames/godot-tts]https://github.com/lightsoutgames/godot-tts[/url]
+License: [url=mit_godot-tts]MIT[/url]"
+text = "Website: https://github.com/lightsoutgames/godot-tts
+License: MIT"
+fit_content_height = true
+
+[node name="AccessibilityFocus" type="Node" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-tts/HBoxContainer/VBoxContainer/RichTextLabel"]
+script = ExtResource( 18 )
+
+[node name="RichTextLabel" type="RichTextLabel" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-tts"]
+margin_top = 108.0
+margin_right = 1002.0
+margin_bottom = 137.0
+bbcode_enabled = true
+bbcode_text = "Addon to interface with screen reader/text-to-speech software across many platforms."
+text = "Addon to interface with screen reader/text-to-speech software across many platforms."
+fit_content_height = true
+
+[node name="AccessibilityFocus" type="Node" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-tts/RichTextLabel"]
+script = ExtResource( 18 )
+next = NodePath("../../../../../..")
+
+[node name="HSeparator" type="HSeparator" parent="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-tts"]
 margin_top = 141.0
 margin_right = 1002.0
 margin_bottom = 145.0
@@ -755,6 +863,10 @@ max_width = 30
 [connection signal="meta_clicked" from="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-videodecoder/RichTextLabel" to="." method="_on_RichTextLabel_meta_clicked"]
 [connection signal="meta_clicked" from="TabContainerHandler/TabContainer/Libraries/VBoxContainer/ControllerIcons/HBoxContainer/VBoxContainer/RichTextLabel" to="." method="_on_RichTextLabel_meta_clicked"]
 [connection signal="meta_clicked" from="TabContainerHandler/TabContainer/Libraries/VBoxContainer/OnScreenKeyboard/HBoxContainer/VBoxContainer/RichTextLabel" to="." method="_on_RichTextLabel_meta_clicked"]
+[connection signal="meta_clicked" from="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-accessibility/HBoxContainer/VBoxContainer/RichTextLabel" to="." method="_on_RichTextLabel_meta_clicked"]
+[connection signal="meta_clicked" from="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-accessibility/RichTextLabel" to="." method="_on_RichTextLabel_meta_clicked"]
+[connection signal="meta_clicked" from="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-tts/HBoxContainer/VBoxContainer/RichTextLabel" to="." method="_on_RichTextLabel_meta_clicked"]
+[connection signal="meta_clicked" from="TabContainerHandler/TabContainer/Libraries/VBoxContainer/godot-tts/RichTextLabel" to="." method="_on_RichTextLabel_meta_clicked"]
 [connection signal="meta_clicked" from="TabContainerHandler/TabContainer/Assets/VBoxContainer/Godot/HBoxContainer/VBoxContainer/RichTextLabel" to="." method="_on_RichTextLabel_meta_clicked"]
 [connection signal="meta_clicked" from="TabContainerHandler/TabContainer/Assets/VBoxContainer/ScreenScraper/HBoxContainer/VBoxContainer/RichTextLabel" to="." method="_on_RichTextLabel_meta_clicked"]
 [connection signal="item_activated" from="TabContainerHandler/TabContainer/Licenses/HBoxContainer/Names" to="TabContainerHandler/TabContainer/Licenses" method="_on_Names_item_activated"]

--- a/scenes/config/Licenses.gd
+++ b/scenes/config/Licenses.gd
@@ -17,6 +17,8 @@ func _ready():
 		["MIT (godot-videodecoder)", "mit_videodecoder.txt"],
 		["MIT (Controller Icons)", "mit_controllericons.txt"],
 		["MIT (Onscreenkeyboard)", "mit_onscreenkeyboard.txt"],
+		["MIT (Godot Accessibility Plugin)", "mit_godot-accessibility.txt"],
+		["MIT (Godot TTS)", "mit_godot-tts.txt"],
 		["CC0", "cc0.txt"],
 		["CC BY 4.0", "ccby40.txt"],
 		["CC BY NC SA 4.0", "ccbyncsa40.txt"]
@@ -71,6 +73,10 @@ func convert_license_key(key: String) -> String:
 			return "MIT (Controller Icons)"
 		"mit_onscreenkeyboard":
 			return "MIT (Onscreenkeyboard)"
+		"mit_godot-accessibility":
+			return "MIT (Godot Accessibility Plugin)"
+		"mit_godot-tts":
+			return "MIT (Godot TTS)"
 		"cc0":
 			return "CC0"
 		"ccby40":


### PR DESCRIPTION
Add credit and license information for [godot-accessibility](https://github.com/lightsoutgames/godot-accessibility) and [godot-tts](https://github.com/lightsoutgames/godot-tts) addons

Closes #228 