### PR TITLE
Disable theme reloading temporarily

### DIFF
--- a/scenes/config/settings/GeneralSettings.gd
+++ b/scenes/config/settings/GeneralSettings.gd
@@ -86,6 +86,9 @@ func _on_Themes_item_selected(index):
 	var theme_path : String = theme_id_map[index]
 	RetroHubConfig.config.current_theme = theme_path
 
+	# FIXME: Theme hot-reloading is disabled until nasty GDScript bug is solved
+	RetroHubUI.show_warning("Theme reloading is temporarily disabled for this version due to an internal bug in RetroHub's engine (Godot).\n \nYou'll have to restart RetroHub manually to switch themes.")
+
 func _on_SetThemePath_pressed():
 	#warning-ignore:return_value_discarded
 	OS.shell_open(RetroHubConfig.get_themes_dir())

--- a/scenes/root/Root.tscn
+++ b/scenes/root/Root.tscn
@@ -87,6 +87,7 @@ script = ExtResource("6")
 unique_name_in_owner = true
 handle_input_locally = false
 size = Vector2i(608, 346)
+popup_window = true
 content_scale_size = Vector2i(608, 346)
 content_scale_mode = 1
 content_scale_aspect = 4

--- a/source/Config.gd
+++ b/source/Config.gd
@@ -427,9 +427,11 @@ func load_theme() -> bool:
 		theme_path = get_themes_dir() + "/" + current_theme
 	else:
 		theme_path = get_default_themes_dir() + "/" + current_theme + ".pck"
-	if !ProjectSettings.load_resource_pack(theme_path, false):
-		push_error("Error when loading theme " + theme_path)
-		return false
+	# FIXME: Theme hot-reloading is disabled until nasty GDScript bug is solved
+	if not ProjectSettings.is_pack_loaded(theme_path):
+		if not ProjectSettings.load_resource_pack(theme_path, false):
+			push_error("Error when loading theme " + theme_path)
+			return false
 
 	load_theme_data()
 	if theme_data.entry_scene:
@@ -470,9 +472,10 @@ func unload_theme():
 		save_theme_config()
 
 		theme_data = null
-		if !ProjectSettings.unload_resource_pack(theme_path):
-			push_error("Error when unloading theme " + theme_path)
-			return
+		# FIXME: Theme hot-reloading is disabled until nasty GDScript bug is solved
+		#if !ProjectSettings.unload_resource_pack(theme_path):
+		#	push_error("Error when unloading theme " + theme_path)
+		#	return
 
 func get_theme_config(key, default_value):
 	if not _theme_config.has(key):


### PR DESCRIPTION
Due to a Godot/GDScript bug (#251), and to not delay v0.2.0 further, this feature will be temporarily disabled.