### PR TITLE
Introduce config versioning

### DIFF
--- a/source/Config.gd
+++ b/source/Config.gd
@@ -404,7 +404,7 @@ func save_game_data(game_data: RetroHubGameData) -> bool:
 		push_error("Error when opening file %s!" % metadata_path)
 		return false
 
-	file.store_string(JSON.stringify(game_data_raw, "\t"))
+	file.store_string(JSON.stringify(game_data_raw, "\t", false))
 	file.close()
 
 	emit_signal("game_data_updated", game_data)
@@ -506,7 +506,7 @@ func save_theme_config():
 		if not file:
 			push_error("Error when saving theme config at %s" % theme_config_path)
 			return
-		file.store_string(JSON.stringify(_theme_config, "\t"))
+		file.store_string(JSON.stringify(_theme_config, "\t", false))
 		file.close()
 
 		for key in _theme_config:

--- a/source/utils/JSONUtils.gd
+++ b/source/utils/JSONUtils.gd
@@ -21,7 +21,7 @@ func save_json_file(json, file_path: String):
 	var file := FileAccess.open(file_path, FileAccess.WRITE)
 	if not file:
 		return FileAccess.get_open_error()
-	file.store_string(JSON.stringify(json, "\t"))
+	file.store_string(JSON.stringify(json, "\t", false))
 	file.close()
 
 func make_system_specific(json: Dictionary, curr_system: String):


### PR DESCRIPTION
RetroHub v0.2.0 introduces the first breaking change to users config, thus a system for finding config versions is now necessary to reliably update/inform users going forward.

Also makes all JSON saving operations not sort keys, which was the default in v0.1

Fixes #250 