### PR TITLE
Fix Windows CI not finding cache

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v3
         id: "cache_template"
         with:
-          path: cached_builds/template/${{ matrix.template }}}
+          path: cached_builds/template/${{ matrix.template }}
           key: Windows-${{ matrix.arch }}-template-build
         continue-on-error: true
 


### PR DESCRIPTION
An extra } was making the cache key fail for Godot templates