### PR TITLE
Implement selecting custom emulators per game

### DIFF
--- a/scenes/config/GameEmulatorEditor.gd
+++ b/scenes/config/GameEmulatorEditor.gd
@@ -1,0 +1,77 @@
+extends Control
+
+signal change_ocurred
+
+@onready var n_intro_lbl := %IntroLabel
+@onready var n_override_emulator := %OverrideEmulator
+@onready var n_emulator_options := %EmulatorOptions
+
+var game_data : RetroHubGameData: set = set_game_data
+
+@export var disable_edits := false
+
+func _ready():
+	#warning-ignore:return_value_discarded
+	RetroHubConfig.game_data_updated.connect(_on_game_data_updated)
+	
+	n_emulator_options.get_popup().max_size.y = RetroHubUI.max_popupmenu_height
+
+func _on_game_data_updated(_game_data: RetroHubGameData):
+	if game_data == _game_data:
+		discard_changes()
+
+func set_game_data(_game_data: RetroHubGameData) -> void:
+	game_data = _game_data
+	update_emulator_options()
+	for idx in n_emulator_options.item_count:
+		if n_emulator_options.get_item_metadata(idx) == game_data.emulator:
+			n_emulator_options.selected = idx
+			break
+	discard_changes()
+
+func update_emulator_options() -> void:
+	n_emulator_options.clear()
+
+	var system_emulators : Array = RetroHubConfig._systems_raw[game_data.system.name]["emulator"]
+	for system_emulator in system_emulators:
+		var emu_short_name : String
+		if system_emulator is Dictionary:
+			emu_short_name = system_emulator.keys()[0]
+		else:
+			emu_short_name = system_emulator
+		if RetroHubConfig.emulators_map.has(emu_short_name):
+			var emu_logo := load("res://assets/emulators/%s.png" % emu_short_name)
+			n_emulator_options.add_icon_item(emu_logo, RetroHubConfig.emulators_map[emu_short_name]["fullname"])
+		else:
+			n_emulator_options.add_item(emu_short_name)
+		n_emulator_options.set_item_metadata(n_emulator_options.item_count-1, emu_short_name)
+
+func discard_changes():
+	if game_data:
+		n_override_emulator.button_pressed = !game_data.emulator.is_empty()
+	else:
+		n_override_emulator.button_pressed = false
+
+
+func save_changes():
+	if game_data:
+		if n_override_emulator.button_pressed:
+			game_data.emulator = n_emulator_options.get_selected_metadata()
+		else:
+			game_data.emulator = ""
+
+func grab_focus():
+	if RetroHubConfig.config.accessibility_screen_reader_enabled:
+		n_intro_lbl.grab_focus()
+	else:
+		n_override_emulator.grab_focus()
+	_on_override_emulator_toggled(n_override_emulator.button_pressed)
+	if n_emulator_options.item_count == 0:
+		update_emulator_options()
+
+func _on_change_ocurred(_tmp = null):
+	emit_signal("change_ocurred")
+
+
+func _on_override_emulator_toggled(button_pressed):
+	n_emulator_options.disabled = !button_pressed

--- a/scenes/config/GameEmulatorEditor.tscn
+++ b/scenes/config/GameEmulatorEditor.tscn
@@ -1,0 +1,85 @@
+[gd_scene load_steps=4 format=3 uid="uid://d7nikimq3mtl"]
+
+[ext_resource type="Script" path="res://scenes/config/GameEmulatorEditor.gd" id="1_l1abn"]
+[ext_resource type="Script" path="res://scenes/ui_nodes/AccessibilityFocus.gd" id="2_1c0xs"]
+[ext_resource type="Script" path="res://source/utils/ScrollHandler.gd" id="4_cjldn"]
+
+[node name="Emulator" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_l1abn")
+
+[node name="ScrollContainer" type="ScrollContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="IntroLabel" type="Label" parent="ScrollContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 0
+text = "Override default emulator?"
+
+[node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/HBoxContainer/IntroLabel"]
+script = ExtResource("2_1c0xs")
+
+[node name="OverrideEmulator" type="CheckButton" parent="ScrollContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="HSeparator" type="HSeparator" parent="ScrollContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="ScrollContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/HBoxContainer2"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 0
+text = "Emulator:"
+
+[node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/HBoxContainer2/Label"]
+script = ExtResource("2_1c0xs")
+
+[node name="EmulatorOptions" type="OptionButton" parent="ScrollContainer/VBoxContainer/HBoxContainer2"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(256, 64)
+layout_mode = 2
+expand_icon = true
+
+[node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/HBoxContainer2/EmulatorOptions"]
+script = ExtResource("2_1c0xs")
+next = NodePath("../../../DisclaimerLabel")
+
+[node name="DisclaimerLabel" type="Label" parent="ScrollContainer/VBoxContainer"]
+layout_mode = 2
+text = "RetroHub will try all these emulators in order until one launches successfully. By overriding this, RetroHub will begin with the chosen emulator, and default to the remaining emulators if it fails."
+autowrap_mode = 2
+
+[node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/DisclaimerLabel"]
+script = ExtResource("2_1c0xs")
+
+[node name="ScrollHandler" type="Control" parent="ScrollContainer"]
+layout_mode = 2
+script = ExtResource("4_cjldn")
+
+[connection signal="pressed" from="ScrollContainer/VBoxContainer/HBoxContainer/OverrideEmulator" to="." method="_on_change_ocurred"]
+[connection signal="toggled" from="ScrollContainer/VBoxContainer/HBoxContainer/OverrideEmulator" to="." method="_on_override_emulator_toggled"]
+[connection signal="item_selected" from="ScrollContainer/VBoxContainer/HBoxContainer2/EmulatorOptions" to="." method="_on_change_ocurred"]

--- a/scenes/config/GameInfoEditor.gd
+++ b/scenes/config/GameInfoEditor.gd
@@ -1,0 +1,53 @@
+extends Control
+
+signal change_ocurred
+
+@onready var n_intro_lbl := %IntroLabel
+@onready var n_favorite := %Favorite
+@onready var n_num_times_played := %NumTimesPlayed
+
+var game_data : RetroHubGameData: set = set_game_data
+
+@export var disable_edits := false
+
+func _ready():
+	#warning-ignore:return_value_discarded
+	RetroHubConfig.game_data_updated.connect(_on_game_data_updated)
+
+func _on_game_data_updated(_game_data: RetroHubGameData):
+	if game_data == _game_data:
+		discard_changes()
+
+func set_game_data(_game_data: RetroHubGameData) -> void:
+	game_data = _game_data
+	discard_changes()
+
+func discard_changes():
+	if game_data:
+		set_edit_nodes_enabled(true)
+		n_favorite.set_pressed_no_signal(game_data.favorite)
+		n_num_times_played.value = game_data.play_count
+	else:
+		set_edit_nodes_enabled(false)
+		n_favorite.set_pressed_no_signal(false)
+		n_num_times_played.value = 0
+
+func set_edit_nodes_enabled(enabled: bool):
+	if disable_edits:
+		enabled = false
+	n_favorite.disabled = !enabled
+	n_num_times_played.editable = enabled
+
+func save_changes():
+	if game_data:
+		game_data.favorite = n_favorite.button_pressed
+		game_data.play_count = n_num_times_played.value
+
+func grab_focus():
+	if RetroHubConfig.config.accessibility_screen_reader_enabled:
+		n_intro_lbl.grab_focus()
+	else:
+		n_favorite.grab_focus()
+
+func _on_change_ocurred(_tmp = null):
+	emit_signal("change_ocurred")

--- a/scenes/config/GameInfoEditor.tscn
+++ b/scenes/config/GameInfoEditor.tscn
@@ -1,0 +1,79 @@
+[gd_scene load_steps=5 format=3 uid="uid://dl6wrbha57kyf"]
+
+[ext_resource type="Script" path="res://scenes/config/GameInfoEditor.gd" id="1_6huq3"]
+[ext_resource type="Script" path="res://scenes/ui_nodes/AccessibilityFocus.gd" id="1_g3g03"]
+[ext_resource type="Script" path="res://source/utils/SpinBoxHandler.gd" id="2_xpxl6"]
+[ext_resource type="Script" path="res://source/utils/ScrollHandler.gd" id="3_e7sx0"]
+
+[node name="Info" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_6huq3")
+
+[node name="ScrollContainer" type="ScrollContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="IntroLabel" type="Label" parent="ScrollContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 0
+text = "Favorite?"
+
+[node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/HBoxContainer/IntroLabel"]
+script = ExtResource("1_g3g03")
+
+[node name="Favorite" type="CheckButton" parent="ScrollContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="ScrollContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/HBoxContainer2"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 0
+text = "Number of times played:"
+
+[node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/HBoxContainer2/Label"]
+script = ExtResource("1_g3g03")
+
+[node name="NumTimesPlayed" type="SpinBox" parent="ScrollContainer/VBoxContainer/HBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+allow_greater = true
+
+[node name="SpinBoxHandler" type="Control" parent="ScrollContainer/VBoxContainer/HBoxContainer2/NumTimesPlayed"]
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+script = ExtResource("2_xpxl6")
+
+[node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/HBoxContainer2/NumTimesPlayed"]
+script = ExtResource("1_g3g03")
+next = NodePath("../../../HBoxContainer/IntroLabel")
+
+[node name="ScrollHandler" type="Control" parent="ScrollContainer"]
+layout_mode = 2
+script = ExtResource("3_e7sx0")
+
+[connection signal="pressed" from="ScrollContainer/VBoxContainer/HBoxContainer/Favorite" to="." method="_on_change_ocurred"]
+[connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer2/NumTimesPlayed" to="." method="_on_change_ocurred"]

--- a/scenes/config/GameMetadataEditor.gd
+++ b/scenes/config/GameMetadataEditor.gd
@@ -1,7 +1,6 @@
 extends Control
 
 signal change_ocurred
-signal reset_state
 
 @onready var n_intro_lbl := %IntroLabel
 @onready var n_name := %Name
@@ -18,8 +17,6 @@ signal reset_state
 @onready var n_variable_players := %VariablePlayers
 @onready var n_variable_players_min := %VariablePlayersMin
 @onready var n_variable_players_max := %VariablePlayersMax
-@onready var n_favorite := %Favorite
-@onready var n_num_times_played := %NumTimesPlayed
 
 var game_data : RetroHubGameData: set = set_game_data
 
@@ -113,8 +110,6 @@ func discard_changes():
 			n_variable_players.set_pressed_no_signal(false)
 			n_variable_players_min.value = 1
 			n_variable_players_max.value = 2
-		n_favorite.set_pressed_no_signal(game_data.favorite)
-		n_num_times_played.value = game_data.play_count
 	else:
 		set_edit_nodes_enabled(false)
 		n_name.text = ""
@@ -131,9 +126,6 @@ func discard_changes():
 		n_variable_players.set_pressed_no_signal(false)
 		n_variable_players_min.value = 1
 		n_variable_players_max.value = 2
-		n_favorite.set_pressed_no_signal(false)
-		n_num_times_played.value = 0
-	emit_signal("reset_state")
 
 func set_edit_nodes_enabled(enabled: bool):
 	if disable_edits:
@@ -151,8 +143,6 @@ func set_edit_nodes_enabled(enabled: bool):
 	n_variable_players.disabled = !enabled
 	n_variable_players_min.editable = enabled
 	n_variable_players_max.editable = enabled
-	n_favorite.disabled = !enabled
-	n_num_times_played.editable = enabled
 
 func save_changes():
 	if game_data:
@@ -177,10 +167,6 @@ func save_changes():
 			game_data.num_players = "%d-%d" % [n_fixed_players_num.value, n_fixed_players_num.value]
 		else:
 			game_data.num_players = "%d-%d" % [n_variable_players_min.value, n_variable_players_max.value]
-		game_data.favorite = n_favorite.button_pressed
-		game_data.play_count = n_num_times_played.value
-		if RetroHubConfig.save_game_data(game_data):
-			emit_signal("reset_state")
 
 func grab_focus():
 	if RetroHubConfig.config.accessibility_screen_reader_enabled:

--- a/scenes/config/GameMetadataEditor.tscn
+++ b/scenes/config/GameMetadataEditor.tscn
@@ -41,7 +41,6 @@ text = "Name:"
 
 [node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/HBoxContainer/IntroLabel"]
 script = ExtResource("9")
-previous = NodePath("../../../HBoxContainer10/NumTimesPlayed")
 
 [node name="Name" type="LineEdit" parent="ScrollContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
@@ -248,7 +247,6 @@ text = "Variable"
 unique_name_in_owner = true
 custom_minimum_size = Vector2(75, 0)
 layout_mode = 2
-focus_neighbor_bottom = NodePath("../../../../HBoxContainer9/Favorite")
 min_value = 1.0
 max_value = 1000.0
 value = 1.0
@@ -269,7 +267,6 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 size_flags_horizontal = 3
-focus_neighbor_bottom = NodePath("../../../../HBoxContainer9/Favorite")
 min_value = 2.0
 max_value = 1000.0
 value = 2.0
@@ -282,48 +279,8 @@ offset_right = 40.0
 offset_bottom = 40.0
 script = ExtResource("8")
 
-[node name="HBoxContainer9" type="HBoxContainer" parent="ScrollContainer/VBoxContainer"]
-layout_mode = 2
-
-[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/HBoxContainer9"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 0
-text = "Favorite?"
-
-[node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/HBoxContainer9/Label"]
+[node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayersMax"]
 script = ExtResource("9")
-
-[node name="Favorite" type="CheckButton" parent="ScrollContainer/VBoxContainer/HBoxContainer9"]
-unique_name_in_owner = true
-layout_mode = 2
-
-[node name="HBoxContainer10" type="HBoxContainer" parent="ScrollContainer/VBoxContainer"]
-layout_mode = 2
-
-[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/HBoxContainer10"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 0
-text = "Number of times played:"
-
-[node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/HBoxContainer10/Label"]
-script = ExtResource("9")
-
-[node name="NumTimesPlayed" type="SpinBox" parent="ScrollContainer/VBoxContainer/HBoxContainer10"]
-unique_name_in_owner = true
-layout_mode = 2
-allow_greater = true
-
-[node name="SpinBoxHandler" type="Control" parent="ScrollContainer/VBoxContainer/HBoxContainer10/NumTimesPlayed"]
-anchors_preset = 0
-offset_right = 40.0
-offset_bottom = 40.0
-script = ExtResource("8")
-
-[node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/HBoxContainer10/NumTimesPlayed"]
-script = ExtResource("9")
-next = NodePath("../../../HBoxContainer/IntroLabel")
 
 [node name="ScrollHandler" type="Control" parent="ScrollContainer"]
 layout_mode = 2
@@ -331,8 +288,8 @@ script = ExtResource("7")
 
 [connection signal="text_changed" from="ScrollContainer/VBoxContainer/HBoxContainer/Name" to="." method="_on_change_ocurred"]
 [connection signal="text_changed" from="ScrollContainer/VBoxContainer/HBoxContainer2/Description" to="." method="_on_change_ocurred"]
-[connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer3/HBoxContainer/Rating" to="." method="_on_change_ocurred"]
 [connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer3/HBoxContainer/Rating" to="." method="_on_Rating_value_changed"]
+[connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer3/HBoxContainer/Rating" to="." method="_on_change_ocurred"]
 [connection signal="text_changed" from="ScrollContainer/VBoxContainer/HBoxContainer4/ReleaseDate" to="." method="_on_change_ocurred"]
 [connection signal="text_changed" from="ScrollContainer/VBoxContainer/HBoxContainer5/Developer" to="." method="_on_change_ocurred"]
 [connection signal="text_changed" from="ScrollContainer/VBoxContainer/HBoxContainer6/Publisher" to="." method="_on_change_ocurred"]
@@ -342,10 +299,8 @@ script = ExtResource("7")
 [connection signal="toggled" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer/FixedPlayers" to="." method="_on_FixedPlayers_toggled"]
 [connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer/FixedPlayersNum" to="." method="_on_change_ocurred"]
 [connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer/FixedPlayersNum" to="." method="_on_FixedPlayersNum_value_changed"]
-[connection signal="toggled" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayers" to="." method="_on_VariablePlayers_toggled"]
 [connection signal="toggled" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayers" to="." method="_on_change_ocurred"]
-[connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayersMin" to="." method="_on_VariablePlayersMin_value_changed"]
+[connection signal="toggled" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayers" to="." method="_on_VariablePlayers_toggled"]
 [connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayersMin" to="." method="_on_change_ocurred"]
+[connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayersMin" to="." method="_on_VariablePlayersMin_value_changed"]
 [connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayersMax" to="." method="_on_change_ocurred"]
-[connection signal="toggled" from="ScrollContainer/VBoxContainer/HBoxContainer9/Favorite" to="." method="_on_change_ocurred"]
-[connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer10/NumTimesPlayed" to="." method="_on_change_ocurred"]

--- a/scenes/config/GameSettings.gd
+++ b/scenes/config/GameSettings.gd
@@ -3,19 +3,74 @@ extends Control
 @onready var n_save_btn := %Save
 @onready var n_discard_btn := %Discard
 
-@onready var n_game_metadata_editor := %GameMetadataEditor
+@onready var n_editor_tab := %EditorTab
+@onready var n_game_metadata_editor := %Metadata
+@onready var n_game_info_editor := %Info
+@onready var n_game_emulator_editor := %Emulator
 
 func set_game_data(game_data: RetroHubGameData) -> void:
+	n_editor_tab.current_tab = 0
 	n_game_metadata_editor.game_data = game_data
+	n_game_info_editor.game_data = game_data
+	n_game_emulator_editor.game_data = game_data
+	_on_reset_state()
 
 func grab_focus():
-	n_game_metadata_editor.grab_focus()
+	# FIXME: For some reason, right shoulder button focus without problem,
+	# but left shoulder button doesn't. Godot bug?
+	# Yielding a frame
+	await get_tree().process_frame
+	match n_editor_tab.current_tab:
+		0:
+			n_game_metadata_editor.grab_focus()
+		1:
+			n_game_info_editor.grab_focus()
+		2:
+			n_game_emulator_editor.grab_focus()
 
-func _on_GameMetadataEditor_change_ocurred():
+func _on_change_ocurred():
 	n_save_btn.disabled = false
 	n_discard_btn.disabled = false
 
 
-func _on_GameMetadataEditor_reset_state():
+func _on_reset_state():
 	n_save_btn.disabled = true
 	n_discard_btn.disabled = true
+
+
+func _on_save_pressed():
+	n_game_metadata_editor.save_changes()
+	n_game_info_editor.save_changes()
+	n_game_emulator_editor.save_changes()
+	if RetroHubConfig.save_game_data(n_game_metadata_editor.game_data):
+		_on_reset_state()
+
+
+func _on_discard_pressed():
+	n_game_metadata_editor.discard_changes()
+	n_game_info_editor.discard_changes()
+	n_game_emulator_editor.discard_changes()
+	_on_reset_state()
+
+
+func _on_editor_tab_changed(tab_container, enter_tab):
+	self.grab_focus()
+
+
+func _on_h_separator_focus_entered():
+	# Focus comes from above
+	self.grab_focus()
+
+
+func _on_editor_tab_focus_entered():
+	# Focus comes from below
+	match n_editor_tab.current_tab:
+		0:
+			%Metadata.get_node("ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayersMax").grab_focus()
+		1:
+			%Info.get_node("ScrollContainer/VBoxContainer/HBoxContainer2/NumTimesPlayed").grab_focus()
+		2:
+			if RetroHubConfig.config.accessibility_screen_reader_enabled:
+				%Emulator.get_node("ScrollContainer/VBoxContainer/DisclaimerLabel").grab_focus()
+			else:
+				%Emulator.get_node("ScrollContainer/VBoxContainer/HBoxContainer2/EmulatorOptions").grab_focus()

--- a/scenes/config/GameSettings.tscn
+++ b/scenes/config/GameSettings.tscn
@@ -1,8 +1,17 @@
-[gd_scene load_steps=4 format=3 uid="uid://dykfd11xmgm5g"]
+[gd_scene load_steps=12 format=3 uid="uid://dykfd11xmgm5g"]
 
 [ext_resource type="Script" path="res://scenes/config/GameSettings.gd" id="1"]
+[ext_resource type="Theme" uid="uid://jtuqhw3am1h3" path="res://resources/default_theme.tres" id="1_b57fu"]
 [ext_resource type="Script" path="res://scenes/ui_nodes/AccessibilityFocus.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://bma07qur4debs" path="res://scenes/config/GameMetadataEditor.tscn" id="3"]
+[ext_resource type="Script" path="res://source/utils/TabContainerHandler.gd" id="3_wx4yf"]
+[ext_resource type="PackedScene" uid="uid://dl6wrbha57kyf" path="res://scenes/config/GameInfoEditor.tscn" id="6_nefgw"]
+[ext_resource type="Texture2D" uid="uid://dim5mk7g4q043" path="res://addons/controller_icons/assets/key/q.png" id="7_hw7oc"]
+[ext_resource type="PackedScene" uid="uid://d7nikimq3mtl" path="res://scenes/config/GameEmulatorEditor.tscn" id="7_sn7t2"]
+[ext_resource type="Script" path="res://addons/controller_icons/objects/TextureRect.gd" id="8_64kof"]
+[ext_resource type="Texture2D" uid="uid://xe4n818le3p8" path="res://addons/controller_icons/assets/key/e.png" id="9_uurvh"]
+
+[sub_resource type="ButtonGroup" id="ButtonGroup_7xm1s"]
 
 [node name="GameSettings" type="Control"]
 layout_mode = 3
@@ -12,6 +21,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 focus_mode = 2
+theme = ExtResource("1_b57fu")
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
@@ -34,41 +44,136 @@ layout_mode = 2
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-focus_neighbor_top = NodePath("../../../GameMetadataEditor/ScrollContainer/VBoxContainer/HBoxContainer10/NumTimesPlayed")
+focus_neighbor_top = NodePath("../../../TabContainerHandler/EditorTab")
 text = "Save changes"
 
 [node name="AccessibilityFocus" type="Node" parent="VBoxContainer/HBoxContainer/HBoxContainer/Save"]
 script = ExtResource("2")
-previous = NodePath("../../../../GameMetadataEditor/ScrollContainer/VBoxContainer/HBoxContainer10/NumTimesPlayed")
+previous = NodePath("../../../../TabContainerHandler/EditorTab")
 
 [node name="Discard" type="Button" parent="VBoxContainer/HBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-focus_neighbor_top = NodePath("../../../GameMetadataEditor/ScrollContainer/VBoxContainer/HBoxContainer10/NumTimesPlayed")
+focus_neighbor_top = NodePath("../../../TabContainerHandler/TabContainer/Metadata/ScrollContainer/VBoxContainer/HBoxContainer10/NumTimesPlayed")
 text = "Discard changes"
 
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
 layout_mode = 2
+focus_mode = 2
 
-[node name="GameMetadataEditor" parent="VBoxContainer" instance=ExtResource("3")]
+[node name="TabContainerHandler" type="Control" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+script = ExtResource("3_wx4yf")
+signal_tab_change = true
+
+[node name="EditorTab" type="TabContainer" parent="VBoxContainer/TabContainerHandler"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+focus_mode = 2
+
+[node name="Metadata" parent="VBoxContainer/TabContainerHandler/EditorTab" instance=ExtResource("3")]
 unique_name_in_owner = true
 layout_mode = 2
-focus_neighbor_top = NodePath("../HBoxContainer/HBoxContainer/Save")
-focus_neighbor_bottom = NodePath("../HBoxContainer/HBoxContainer/Save")
+focus_neighbor_top = NodePath("../../../HBoxContainer/HBoxContainer/Save")
+focus_neighbor_bottom = NodePath("../../../HBoxContainer/HBoxContainer/Save")
 
-[node name="AccessibilityFocus" parent="VBoxContainer/GameMetadataEditor/ScrollContainer/VBoxContainer/HBoxContainer/IntroLabel" index="0"]
-previous = NodePath("../../../../../../HBoxContainer/HBoxContainer/Discard")
+[node name="AccessibilityFocus" parent="VBoxContainer/TabContainerHandler/EditorTab/Metadata/ScrollContainer/VBoxContainer/HBoxContainer/IntroLabel" index="0"]
+previous = NodePath("../../../../../../../../HBoxContainer/HBoxContainer/Save")
 
-[node name="NumTimesPlayed" parent="VBoxContainer/GameMetadataEditor/ScrollContainer/VBoxContainer/HBoxContainer10" index="1"]
-focus_neighbor_bottom = NodePath("../../../../../HBoxContainer/HBoxContainer/Save")
+[node name="Name" parent="VBoxContainer/TabContainerHandler/EditorTab/Metadata/ScrollContainer/VBoxContainer/HBoxContainer" index="1"]
+focus_neighbor_top = NodePath("../../../../../../../HBoxContainer/HBoxContainer/Save")
 
-[node name="AccessibilityFocus" parent="VBoxContainer/GameMetadataEditor/ScrollContainer/VBoxContainer/HBoxContainer10/NumTimesPlayed" index="3"]
-next = NodePath("../../../../../../HBoxContainer/HBoxContainer/Save")
+[node name="FixedPlayers" parent="VBoxContainer/TabContainerHandler/EditorTab/Metadata/ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer" index="0"]
+button_group = SubResource("ButtonGroup_7xm1s")
 
-[connection signal="pressed" from="VBoxContainer/HBoxContainer/HBoxContainer/Save" to="VBoxContainer/GameMetadataEditor" method="save_changes"]
-[connection signal="pressed" from="VBoxContainer/HBoxContainer/HBoxContainer/Discard" to="VBoxContainer/GameMetadataEditor" method="discard_changes"]
-[connection signal="change_ocurred" from="VBoxContainer/GameMetadataEditor" to="." method="_on_GameMetadataEditor_change_ocurred"]
-[connection signal="reset_state" from="VBoxContainer/GameMetadataEditor" to="." method="_on_GameMetadataEditor_reset_state"]
+[node name="VariablePlayers" parent="VBoxContainer/TabContainerHandler/EditorTab/Metadata/ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2" index="0"]
+focus_neighbor_bottom = NodePath("../../../../../../../../../HBoxContainer/HBoxContainer/Save")
+button_group = SubResource("ButtonGroup_7xm1s")
 
-[editable path="VBoxContainer/GameMetadataEditor"]
+[node name="VariablePlayersMin" parent="VBoxContainer/TabContainerHandler/EditorTab/Metadata/ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2" index="1"]
+focus_neighbor_bottom = NodePath("../../../../../../../../../HBoxContainer/HBoxContainer/Save")
+
+[node name="VariablePlayersMax" parent="VBoxContainer/TabContainerHandler/EditorTab/Metadata/ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2" index="3"]
+focus_neighbor_bottom = NodePath("../../../../../../../../../HBoxContainer/HBoxContainer/Save")
+
+[node name="AccessibilityFocus" parent="VBoxContainer/TabContainerHandler/EditorTab/Metadata/ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayersMax" index="3"]
+next = NodePath("../../../../../../../../../../HBoxContainer/HBoxContainer/Save")
+
+[node name="Info" parent="VBoxContainer/TabContainerHandler/EditorTab" instance=ExtResource("6_nefgw")]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+
+[node name="AccessibilityFocus" parent="VBoxContainer/TabContainerHandler/EditorTab/Info/ScrollContainer/VBoxContainer/HBoxContainer/IntroLabel" index="0"]
+previous = NodePath("../../../../../../../../HBoxContainer/HBoxContainer/Save")
+
+[node name="Favorite" parent="VBoxContainer/TabContainerHandler/EditorTab/Info/ScrollContainer/VBoxContainer/HBoxContainer" index="1"]
+focus_neighbor_top = NodePath("../../../../../../../HBoxContainer/HBoxContainer/Save")
+
+[node name="NumTimesPlayed" parent="VBoxContainer/TabContainerHandler/EditorTab/Info/ScrollContainer/VBoxContainer/HBoxContainer2" index="1"]
+focus_neighbor_bottom = NodePath("../../../../../../../HBoxContainer/HBoxContainer/Save")
+
+[node name="AccessibilityFocus" parent="VBoxContainer/TabContainerHandler/EditorTab/Info/ScrollContainer/VBoxContainer/HBoxContainer2/NumTimesPlayed" index="3"]
+next = NodePath("../../../../../../../../HBoxContainer/HBoxContainer/Save")
+
+[node name="Emulator" parent="VBoxContainer/TabContainerHandler/EditorTab" instance=ExtResource("7_sn7t2")]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+
+[node name="AccessibilityFocus" parent="VBoxContainer/TabContainerHandler/EditorTab/Emulator/ScrollContainer/VBoxContainer/HBoxContainer/IntroLabel" index="0"]
+previous = NodePath("../../../../../../../../HBoxContainer/HBoxContainer/Save")
+
+[node name="OverrideEmulator" parent="VBoxContainer/TabContainerHandler/EditorTab/Emulator/ScrollContainer/VBoxContainer/HBoxContainer" index="1"]
+focus_neighbor_top = NodePath("../../../../../../../HBoxContainer/HBoxContainer/Save")
+
+[node name="EmulatorOptions" parent="VBoxContainer/TabContainerHandler/EditorTab/Emulator/ScrollContainer/VBoxContainer/HBoxContainer2" index="1"]
+focus_neighbor_bottom = NodePath("../../../../../../../HBoxContainer/HBoxContainer/Save")
+
+[node name="AccessibilityFocus" parent="VBoxContainer/TabContainerHandler/EditorTab/Emulator/ScrollContainer/VBoxContainer/DisclaimerLabel" index="0"]
+next = NodePath("../../../../../../../HBoxContainer/HBoxContainer/Save")
+
+[node name="ControllerSlideLeft" type="TextureRect" parent="VBoxContainer/TabContainerHandler"]
+custom_minimum_size = Vector2(30, 30)
+layout_mode = 0
+offset_top = 1.0
+offset_right = 30.0
+offset_bottom = 31.0
+texture = ExtResource("7_hw7oc")
+expand_mode = 1
+script = ExtResource("8_64kof")
+path = "rh_left_shoulder"
+max_width = 30
+
+[node name="ControllerSlideRight" type="TextureRect" parent="VBoxContainer/TabContainerHandler"]
+custom_minimum_size = Vector2(30, 30)
+layout_mode = 0
+offset_left = 262.0
+offset_top = 1.0
+offset_right = 292.0
+offset_bottom = 31.0
+texture = ExtResource("9_uurvh")
+expand_mode = 1
+script = ExtResource("8_64kof")
+path = "rh_right_shoulder"
+max_width = 30
+
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/HBoxContainer/Save" to="." method="_on_save_pressed"]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/HBoxContainer/Discard" to="." method="_on_discard_pressed"]
+[connection signal="focus_entered" from="VBoxContainer/HSeparator" to="." method="_on_h_separator_focus_entered"]
+[connection signal="tab_changed" from="VBoxContainer/TabContainerHandler" to="." method="_on_editor_tab_changed"]
+[connection signal="focus_entered" from="VBoxContainer/TabContainerHandler/EditorTab" to="." method="_on_editor_tab_focus_entered"]
+[connection signal="change_ocurred" from="VBoxContainer/TabContainerHandler/EditorTab/Metadata" to="." method="_on_change_ocurred"]
+[connection signal="change_ocurred" from="VBoxContainer/TabContainerHandler/EditorTab/Info" to="." method="_on_change_ocurred"]
+[connection signal="change_ocurred" from="VBoxContainer/TabContainerHandler/EditorTab/Emulator" to="." method="_on_change_ocurred"]
+
+[editable path="VBoxContainer/TabContainerHandler/EditorTab/Metadata"]
+[editable path="VBoxContainer/TabContainerHandler/EditorTab/Info"]
+[editable path="VBoxContainer/TabContainerHandler/EditorTab/Emulator"]

--- a/source/Config.gd
+++ b/source/Config.gd
@@ -373,6 +373,8 @@ func fetch_game_data(path: String, game: RetroHubGameData) -> bool:
 	game.play_count = data["play_count"]
 	game.last_played = data["last_played"]
 	game.has_media = data["has_media"]
+	if data.has("emulator"):
+		game.emulator = data["emulator"]
 
 	return true
 
@@ -396,6 +398,7 @@ func save_game_data(game_data: RetroHubGameData) -> bool:
 		"play_count": game_data.play_count,
 		"last_played": game_data.last_played,
 		"has_media": game_data.has_media,
+		"emulator": game_data.emulator
 	}
 
 	var file := FileAccess.open(metadata_path, FileAccess.WRITE)

--- a/source/RetroHub.gd
+++ b/source/RetroHub.gd
@@ -160,6 +160,16 @@ func launch_game() -> void:
 
 func _launch_game_process() -> int:
 	var system_emulators : Array = RetroHubConfig._systems_raw[launched_system_data.name]["emulator"]
+	if !launched_game_data.emulator.is_empty():
+		var key = launched_game_data.emulator
+		# If emulator is retroarch, emulator info is a dictionary
+		if key == "retroarch":
+			for item in system_emulators:
+				if item is Dictionary and item.has("retroarch"):
+					key = item
+					break
+		system_emulators.erase(key)
+		system_emulators.push_front(key)
 	var emulators := RetroHubConfig.emulators_map
 	for system_emulator in system_emulators:
 		var emulator

--- a/source/data/GameData.gd
+++ b/source/data/GameData.gd
@@ -23,6 +23,7 @@ func copy_from(other: RetroHubGameData) -> void:
 	favorite = other.favorite
 	play_count = other.play_count
 	last_played = other.last_played
+	emulator = other.emulator
 
 ## Whether this game already has metadata; if it doesn't, you should
 ## present a much simpler view of it
@@ -83,3 +84,7 @@ var play_count : int
 ## to show this information correctly according to the user's preferences.
 ## May be equal to "null" if game hasn't been played yet
 var last_played : String
+
+## Custom emulator to run this game on, overriding default values.
+## If non-empty, specifies a valid emulator name
+var emulator : String

--- a/source/utils/TabContainerHandler.gd
+++ b/source/utils/TabContainerHandler.gd
@@ -22,6 +22,7 @@ func _ready():
 	if not tab or not tab is TabContainer:
 		push_error("TabContainerHandler has no TabContainer child! Queueing free...")
 		queue_free()
+	tab.tab_clicked.connect(_on_tab_clicked)
 
 func _on_focus_entered():
 	_focused = true
@@ -35,7 +36,8 @@ func _input(event):
 	if is_visible_in_tree():
 		if event.is_action_pressed("rh_left_shoulder") or \
 			(_focused and event.is_action_pressed("ui_left")):
-			get_viewport().set_input_as_handled()
+			if is_key_event_on_text(event):
+				return
 			if tab.current_tab > 0:
 				tab.current_tab -= 1
 			else:
@@ -43,6 +45,8 @@ func _input(event):
 			handle_focus(not _focused)
 		elif event.is_action_pressed("rh_right_shoulder") or \
 			(_focused and event.is_action_pressed("ui_right")):
+			if is_key_event_on_text(event):
+				return
 			get_viewport().set_input_as_handled()
 			if tab.current_tab < tab.get_tab_count() - 1:
 				tab.current_tab += 1
@@ -53,6 +57,15 @@ func _input(event):
 			event.is_action_pressed("rh_accept")):
 			get_viewport().set_input_as_handled()
 			handle_focus(true)
+
+func is_key_event_on_text(event: InputEvent):
+	if event is InputEventKey:
+		var control := get_viewport().gui_get_focus_owner()
+		return (control is LineEdit or control is CodeEdit) and control.editable
+	return false
+
+func _on_tab_clicked(tab_idx: int):
+	handle_focus(not _focused)
 
 func handle_focus(enter_tab: bool):
 	if signal_tab_change:


### PR DESCRIPTION
Users can now run specific games under a specific emulator. The way this work doesn't ditch the existing fallback default emulator list; it simply gives priority to the chosen emulator. If the chosen emulator doesn't run, then the fallback is still used.
![image](https://github.com/retrohub-org/retrohub/assets/6501975/83d5998b-d509-4863-b39a-77ba34be36a2)

Since this introduces tabs to the game data editor, I've also taken the opportunity to separate player specific info into an "Info" property, separating it from metadata.

This also fixes some controller focus issues on TabContainerHandler.

Closes #197 