### PR TITLE
Expose clear media cache methods

### DIFF
--- a/scenes/root/Viewport.gd
+++ b/scenes/root/Viewport.gd
@@ -3,7 +3,7 @@ extends SubViewport
 @onready var n_theme_node : Node = $NoTheme
 
 func set_theme(scene: PackedScene):
-	RetroHubMedia._clear_media_cache()
+	RetroHubMedia.clear_all_media_cache()
 	n_theme_node = scene.instantiate()
 	add_child(n_theme_node)
 

--- a/source/Media.gd
+++ b/source/Media.gd
@@ -68,7 +68,10 @@ func t_process_media_requests():
 		var media_data := retrieve_media_data(game_data, types)
 		call_deferred("emit_signal", "media_loaded", media_data, game_data, types)
 
-func _clear_media_cache():
+func clear_media_cache(data: RetroHubGameData):
+	_media_cache.erase(data)
+
+func clear_all_media_cache():
 	_media_cache.clear()
 
 func convert_type_bitmask_to_list(bitmask: int) -> Array:


### PR DESCRIPTION
In the future, it might be possible to do a GC system for unused media cache. But in the meantime (and this way also being configurable for developers), exposes API to remove media from cache.