### PR TITLE
Fix age rating forced size

### DIFF
--- a/scenes/ui_nodes/AgeRatingTextureRect.tscn
+++ b/scenes/ui_nodes/AgeRatingTextureRect.tscn
@@ -1,15 +1,14 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=3 format=3 uid="uid://77ye7lqgs7p4"]
 
-[ext_resource path="res://scenes/ui_nodes/AgeRatingTextureRect.gd" type="Script" id=1]
-[ext_resource path="res://scenes/ui_nodes/AccessibilityFocus.gd" type="Script" id=2]
+[ext_resource type="Script" path="res://scenes/ui_nodes/AgeRatingTextureRect.gd" id="1"]
+[ext_resource type="Script" path="res://scenes/ui_nodes/AccessibilityFocus.gd" id="2"]
 
 [node name="AgeRatingTextureRect" type="TextureRect"]
 offset_right = 40.0
 offset_bottom = 40.0
-custom_minimum_size = Vector2( 80, 100 )
-expand = true
-stretch_mode = 6
-script = ExtResource( 1 )
+expand_mode = 1
+stretch_mode = 5
+script = ExtResource("1")
 
 [node name="AccessibilityFocus" type="Node" parent="."]
-script = ExtResource( 2 )
+script = ExtResource("2")


### PR DESCRIPTION
The age rating used to force a 80x100 size. This can look bad on themes that don't have such space, so it was changed to not force minimum size, and instead resize with aspect ratio.