### PR TITLE
Fix config and scraper popup sizes

### DIFF
--- a/scenes/config/ConfigPopup.gd
+++ b/scenes/config/ConfigPopup.gd
@@ -39,7 +39,7 @@ func _input(event: InputEvent):
 				last_tab = n_game_tab
 			last_tab.grab_focus()
 
-func popup(_rect: Rect2i = Rect2i(0, 0, 0, 0)):
+func open_config():
 	super.popup_centered_ratio(0.8)
 	_on_ConfigPopup_about_to_show()
 

--- a/scenes/config/ScraperSettings.gd
+++ b/scenes/config/ScraperSettings.gd
@@ -124,7 +124,7 @@ func get_media_bitmask() -> int:
 
 func _on_Scrape_pressed():
 	n_ss_settings.save_credentials()
-	n_scrape_popup.popup_centered()
+	n_scrape_popup.popup_centered_ratio(0.8)
 	var media_bitmask := get_media_bitmask()
 	# TODO: Make Scraper generation dynamic according to selection
 	var scraper := RetroHubScreenScraperScraper.new()

--- a/scenes/root/Root.gd
+++ b/scenes/root/Root.gd
@@ -30,7 +30,7 @@ func _raw_input(event: InputEvent):
 		if event.is_action_pressed("rh_menu") and not RetroHubConfig.config.is_first_time:
 			if not $ConfigPopup.visible:
 				get_viewport().set_input_as_handled()
-				$ConfigPopup.popup()
+				$ConfigPopup.open_config()
 
 func _ready():
 	closed_popup(null)

--- a/source/UI.gd
+++ b/source/UI.gd
@@ -140,7 +140,7 @@ func open_app_config(tab: int = -1):
 			_n_config_popup.n_tab_buttons[tab].grab_focus()
 			_n_config_popup.n_tab_buttons[tab].button_pressed = true
 			_n_config_popup._on_Tab_pressed(tab)
-		_n_config_popup.popup_centered()
+		_n_config_popup.open_config()
 
 func show_warning(text: String):
 	if _n_warning_popup:


### PR DESCRIPTION
On certain scenarios, the config popup could be opened without resetting it's size. Same for scraper popup.