### PR TITLE
Support JPEG files in media

### DIFF
--- a/addons/godot-accessibility/ScreenReader.gd
+++ b/addons/godot-accessibility/ScreenReader.gd
@@ -127,7 +127,7 @@ func try_to_get_text_in_theme(theme, texture):
 	if theme == null:
 		return ""
 
-	for type in theme.get_type_list(""):
+	for type in theme.get_type_list():
 		for icon in theme.get_icon_list(type):
 			var icon_texture = theme.get_icon(icon, type)
 			if icon_texture == texture:
@@ -137,15 +137,13 @@ func try_to_get_text_in_theme(theme, texture):
 
 
 func _get_graphical_button_text(texture):
-	var default_theme_copy = Theme.new()
-	default_theme_copy.copy_default_theme()
 	var current = node
 	while current != null:
 		var text = try_to_get_text_in_theme(current.theme, texture)
 		if text != "":
 			return text
 		current = current.get_parent_control()
-	return try_to_get_text_in_theme(default_theme_copy, texture)
+	return ""
 
 
 func _texturebutton_focused():

--- a/source/Media.gd
+++ b/source/Media.gd
@@ -119,15 +119,35 @@ func convert_type_to_media_path(type: int) -> String:
 		_:
 			return "unknown"
 
+func _find_image_path(path: String) -> String:
+	var extensions : Array[String] = [
+		".png", ".jpg"
+	]
+	for ext in extensions:
+		var full_path := path + ext
+		if FileAccess.file_exists(full_path):
+			return full_path
+	return ""
+
+func _find_video_path(path: String) -> String:
+	var extensions : Array[String] = [
+		".mp4"
+	]
+	for ext in extensions:
+		var full_path := path + ext
+		if FileAccess.file_exists(full_path):
+			return full_path
+	return ""
+
 func _load_media(media: RetroHubGameMediaData, game_data: RetroHubGameData, types: Type):
 	var media_path := RetroHubConfig.get_gamemedia_dir().path_join(game_data.system_path)
 	var game_path := game_data.path.get_file().get_basename()
 	
 	var path : String
 	# Logo
-	if not media.logo:
-		path = media_path + "/logo/" + game_path + ".png"
-		if types & Type.LOGO and FileAccess.file_exists(path):
+	if not media.logo and types & Type.LOGO:
+		path = _find_image_path(media_path.path_join("logo").path_join(game_path))
+		if not path.is_empty():
 			var image := Image.load_from_file(path)
 			image.generate_mipmaps()
 			var image_texture := ImageTexture.create_from_image(image)
@@ -137,9 +157,9 @@ func _load_media(media: RetroHubGameMediaData, game_data: RetroHubGameData, type
 				media.logo = image_texture
 
 	# Screenshot
-	if not media.screenshot:
-		path = media_path + "/screenshot/" + game_path + ".png"
-		if types & Type.SCREENSHOT and FileAccess.file_exists(path):
+	if not media.screenshot and types & Type.SCREENSHOT:
+		path = _find_image_path(media_path.path_join("screenshot").path_join(game_path))
+		if not path.is_empty():
 			var image := Image.load_from_file(path)
 			image.generate_mipmaps()
 			var image_texture := ImageTexture.create_from_image(image)
@@ -149,9 +169,9 @@ func _load_media(media: RetroHubGameMediaData, game_data: RetroHubGameData, type
 				media.screenshot = image_texture
 
 	# Title screen
-	if not media.title_screen:
-		path = media_path + "/title-screen/" + game_path + ".png"
-		if types & Type.TITLE_SCREEN and FileAccess.file_exists(path):
+	if not media.title_screen and types & Type.TITLE_SCREEN:
+		path = _find_image_path(media_path.path_join("title-screen").path_join(game_path))
+		if not path.is_empty():
 			var image := Image.load_from_file(path)
 			image.generate_mipmaps()
 			var image_texture := ImageTexture.create_from_image(image)
@@ -161,9 +181,9 @@ func _load_media(media: RetroHubGameMediaData, game_data: RetroHubGameData, type
 				media.title_screen = image_texture
 
 	# Box render
-	if not media.box_render:
-		path = media_path + "/box-render/" + game_path + ".png"
-		if types & Type.BOX_RENDER and FileAccess.file_exists(path):
+	if not media.box_render and types & Type.BOX_RENDER:
+		path = _find_image_path(media_path.path_join("box-render").path_join(game_path))
+		if not path.is_empty():
 			var image := Image.load_from_file(path)
 			image.generate_mipmaps()
 			var image_texture := ImageTexture.create_from_image(image)
@@ -173,9 +193,9 @@ func _load_media(media: RetroHubGameMediaData, game_data: RetroHubGameData, type
 				media.box_render = image_texture
 
 	# Box texture
-	if not media.box_texture:
-		path = media_path + "/box-texture/" + game_path + ".png"
-		if types & Type.BOX_TEXTURE and FileAccess.file_exists(path):
+	if not media.box_texture and types & Type.BOX_TEXTURE:
+		path = _find_image_path(media_path.path_join("box-texture").path_join(game_path))
+		if not path.is_empty():
 			var image := Image.load_from_file(path)
 			image.generate_mipmaps()
 			var image_texture := ImageTexture.create_from_image(image)
@@ -185,9 +205,9 @@ func _load_media(media: RetroHubGameMediaData, game_data: RetroHubGameData, type
 				media.box_texture = image_texture
 
 	# Support render
-	if not media.support_render:
-		path = media_path + "/support-render/" + game_path + ".png"
-		if types & Type.SUPPORT_RENDER and FileAccess.file_exists(path):
+	if not media.support_render and types & Type.SUPPORT_RENDER:
+		path = _find_image_path(media_path.path_join("support-render").path_join(game_path))
+		if not path.is_empty():
 			var image := Image.load_from_file(path)
 			image.generate_mipmaps()
 			var image_texture := ImageTexture.create_from_image(image)
@@ -197,9 +217,9 @@ func _load_media(media: RetroHubGameMediaData, game_data: RetroHubGameData, type
 				media.support_render = image_texture
 
 	# Support texture
-	if not media.support_texture:
-		path = media_path + "/support-texture/" + game_path + ".png"
-		if types & Type.SUPPORT_TEXTURE and FileAccess.file_exists(path):
+	if not media.support_texture and types & Type.SUPPORT_TEXTURE:
+		path = _find_image_path(media_path.path_join("support-texture").path_join(game_path))
+		if not path.is_empty():
 			var image := Image.load_from_file(path)
 			image.generate_mipmaps()
 			var image_texture := ImageTexture.create_from_image(image)
@@ -209,9 +229,9 @@ func _load_media(media: RetroHubGameMediaData, game_data: RetroHubGameData, type
 				media.support_texture = image_texture
 
 	# Video
-	if not media.video:
-		path = media_path + "/video/" + game_path + ".mp4"
-		if types & Type.VIDEO and FileAccess.file_exists(path):
+	if not media.video and types & Type.VIDEO:
+		path = _find_video_path(media_path.path_join("video").path_join(game_path))
+		if not path.is_empty():
 			var video_stream := VideoStreamFFMPEG.new()
 			video_stream.set_file(path)
 			media.video = video_stream


### PR DESCRIPTION
ScreenScraper started using JPEG files for newer systems. Likewise, users might manually use JPEG files, so support was added.