### PR TITLE
Update default theme

### DIFF
--- a/.github/actions/get-default-themes/action.yml
+++ b/.github/actions/get-default-themes/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: sh
       env:
         THEME_NAME: default.pck
-        THEME_VERSION: v0.2.0-beta
+        THEME_VERSION: v0.3.0-beta
       run: |
         cd themes_workdir
         curl -L https://github.com/retrohub-org/default-theme/releases/download/${{ env.THEME_VERSION }}/${{ env.THEME_NAME }} --output ${{ env.THEME_NAME }}


### PR DESCRIPTION
The default theme got a big overhaul (https://github.com/retrohub-org/default-theme/pull/44), so it's better to bundle this already for people to start testing it out.