### PR TITLE
Fix config popup losing focus after modal popups

### DIFF
--- a/scenes/config/ConfigPopup.gd
+++ b/scenes/config/ConfigPopup.gd
@@ -2,6 +2,9 @@ extends Window
 
 signal popup_hide
 
+@onready var n_filesystem_popup := %FileSystemPopup
+@onready var n_warning_popup := %WarningPopup
+
 @onready var n_main := %SettingsTab
 @onready var n_game_tab := %GameTab
 @onready var n_panel_container := %PanelContainer
@@ -22,6 +25,9 @@ func _ready():
 	last_tab = n_game_tab
 	n_panel_container.get_parent().custom_minimum_size.y = n_panel_container.size.y
 	n_panel_container.get_parent().update_minimum_size()
+
+	RetroHubUI._n_filesystem_popup = n_filesystem_popup
+	RetroHubUI._n_warning_popup = n_warning_popup
 
 func _input(event: InputEvent):
 	if not RetroHub._running_game:

--- a/scenes/config/ConfigPopup.tscn
+++ b/scenes/config/ConfigPopup.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=27 format=3 uid="uid://cjx4cfx0f2k2"]
+[gd_scene load_steps=28 format=3 uid="uid://cjx4cfx0f2k2"]
 
 [ext_resource type="Theme" uid="uid://jtuqhw3am1h3" path="res://resources/default_theme.tres" id="1"]
 [ext_resource type="Texture2D" uid="uid://du66o2pueo6qh" path="res://assets/icons/config/emulators.png" id="2"]
@@ -25,6 +25,7 @@
 [ext_resource type="Texture2D" uid="uid://7qv28u4mq7xl" path="res://assets/icons/config/about.png" id="23"]
 [ext_resource type="Script" path="res://source/utils/ScrollHandler.gd" id="24"]
 [ext_resource type="Script" path="res://scenes/ui_nodes/AccessibilityFocus.gd" id="25"]
+[ext_resource type="Script" path="res://scenes/root/FileSystemPopup.gd" id="26_sbwuo"]
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_l35le"]
 
@@ -33,9 +34,12 @@ disable_3d = true
 transparent_bg = true
 initial_position = 1
 size = Vector2i(1000, 480)
+transient = true
 exclusive = true
 borderless = true
 transparent = true
+popup_window = true
+content_scale_size = Vector2i(1000, 480)
 content_scale_mode = 1
 content_scale_aspect = 3
 theme = ExtResource("1")
@@ -464,6 +468,46 @@ layout_mode = 2
 visible = false
 layout_mode = 2
 
+[node name="FileSystemPopup" type="FileDialog" parent="."]
+unique_name_in_owner = true
+title = "Open a File"
+position = Vector2i(0, 24)
+size = Vector2i(949, 477)
+popup_window = true
+theme = ExtResource("1")
+ok_button_text = "Open"
+file_mode = 0
+access = 2
+script = ExtResource("26_sbwuo")
+
+[node name="WarningPopup" type="AcceptDialog" parent="."]
+unique_name_in_owner = true
+handle_input_locally = false
+size = Vector2i(608, 346)
+popup_window = true
+content_scale_size = Vector2i(608, 346)
+content_scale_mode = 1
+content_scale_aspect = 4
+theme = ExtResource("1")
+
+[node name="WarningLabel" type="Label" parent="WarningPopup"]
+unique_name_in_owner = true
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_top = 8.0
+offset_right = -8.0
+offset_bottom = -49.0
+text = "
+"
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 3
+clip_text = true
+text_overrun_behavior = 3
+
+[connection signal="close_requested" from="." to="." method="_on_close_requested"]
 [connection signal="focus_entered" from="Panel/HBoxContainer/ScrollContainer" to="." method="_on_ScrollContainer_focus_entered"]
 [connection signal="button_up" from="Panel/HBoxContainer/ScrollContainer/Panel/PanelContainer/QuitTab" to="." method="_on_Tab_pressed" binds= [0]]
 [connection signal="focus_entered" from="Panel/HBoxContainer/ScrollContainer/Panel/PanelContainer/QuitTab" to="." method="_on_Tab_focus_entered" binds= [0]]
@@ -488,3 +532,6 @@ layout_mode = 2
 [connection signal="focus_entered" from="Panel/HBoxContainer/MarginContainer/SettingsTab" to="." method="_on_SettingsTab_focus_entered"]
 [connection signal="theme_reload" from="Panel/HBoxContainer/MarginContainer/SettingsTab/RegionSettings" to="." method="_on_theme_reload"]
 [connection signal="theme_reload" from="Panel/HBoxContainer/MarginContainer/SettingsTab/SystemSettings" to="." method="_on_theme_reload"]
+[connection signal="about_to_popup" from="FileSystemPopup" to="FileSystemPopup" method="_on_about_to_popup"]
+[connection signal="close_requested" from="FileSystemPopup" to="FileSystemPopup" method="restore_window_focus"]
+[connection signal="focus_exited" from="FileSystemPopup" to="FileSystemPopup" method="restore_window_focus"]

--- a/scenes/popups/scraper/ScraperPopup.tscn
+++ b/scenes/popups/scraper/ScraperPopup.tscn
@@ -25,7 +25,6 @@ transient = true
 exclusive = true
 borderless = true
 transparent = true
-popup_window = true
 content_scale_size = Vector2i(953, 542)
 content_scale_mode = 1
 content_scale_aspect = 4

--- a/scenes/root/Root.gd
+++ b/scenes/root/Root.gd
@@ -4,26 +4,18 @@ extends Control
 @onready var n_viewport := $SubViewportContainer/SubViewport
 
 @onready var n_config_popup := $ConfigPopup
-@onready var n_filesystem_popup := $FileSystemPopup
 @onready var n_keyboard_popup := %Keyboard
-@onready var n_warning_popup := %WarningPopup
 
-@onready var popup_nodes := [
-	n_config_popup,
-	n_filesystem_popup
-]
-
-@onready var viewport_orig_size := Vector2(1162, 648)
+@onready var viewport_orig_size := Vector2(
+	ProjectSettings.get_setting("display/window/size/viewport_width"),
+	ProjectSettings.get_setting("display/window/size/viewport_height")
+)
 
 var n_last_focused : Control
 var is_popup_open : bool = false
 
-var resources_remap := []
-
 func _enter_tree():
 	load("res://scenes/ui_nodes/AccessibilityFocus.gd").take_over_path("res://addons/retrohub_theme_helper/ui/AccessibilityFocus.gd")
-	#resources_remap.append_array([
-	#])
 
 func _raw_input(event: InputEvent):
 	if not RetroHub._running_game:
@@ -43,10 +35,8 @@ func _ready():
 	RetroHubConfig.config_updated.connect(_on_config_updated)
 
 	# Add popups to UI singleton
-	RetroHubUI._n_filesystem_popup = n_filesystem_popup
-	RetroHubUI._n_virtual_keyboard = n_keyboard_popup
 	RetroHubUI._n_config_popup = n_config_popup
-	RetroHubUI._n_warning_popup = n_warning_popup
+	RetroHubUI._n_virtual_keyboard = n_keyboard_popup
 
 	# Handle viewport changes
 	#warning-ignore:return_value_discarded
@@ -84,7 +74,6 @@ func setup_controller_remap(remap_str: String):
 func show_first_time_popup():
 	var first_time_popup : Window = load("res://scenes/popups/first_time/FirstTimePopups.tscn").instantiate()
 	add_child(first_time_popup)
-	popup_nodes.push_back(first_time_popup)
 	#warning-ignore:return_value_discarded
 	first_time_popup.about_to_popup.connect(opened_popup)
 	#warning-ignore:return_value_discarded

--- a/scenes/root/Root.tscn
+++ b/scenes/root/Root.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://c60kwat0su1y"]
+[gd_scene load_steps=11 format=3 uid="uid://c60kwat0su1y"]
 
 [ext_resource type="Script" path="res://scenes/root/Root.gd" id="1"]
 [ext_resource type="Script" path="res://addons/onscreenkeyboard/onscreen_keyboard.gd" id="2"]
@@ -6,7 +6,6 @@
 [ext_resource type="Script" path="res://scenes/root/Viewport.gd" id="4"]
 [ext_resource type="Theme" uid="uid://jtuqhw3am1h3" path="res://resources/default_theme.tres" id="5"]
 [ext_resource type="Shader" path="res://resources/shaders/MenuBlur.gdshader" id="5_co422"]
-[ext_resource type="Script" path="res://scenes/root/FileSystemPopup.gd" id="6"]
 [ext_resource type="Script" path="res://addons/godot-accessibility/ScreenReader.gd" id="7"]
 [ext_resource type="Script" path="res://source/utils/InputHandler.gd" id="9_5ltce"]
 [ext_resource type="PackedScene" uid="uid://dmcmcyq0jach5" path="res://scenes/no_theme/NoTheme.tscn" id="10"]
@@ -57,46 +56,7 @@ focus_mode = 2
 [node name="ConfigPopup" parent="." instance=ExtResource("3")]
 handle_input_locally = false
 visible = false
-content_scale_size = Vector2i(1000, 480)
 content_scale_aspect = 4
-
-[node name="FileSystemPopup" type="FileDialog" parent="."]
-title = "Open a File"
-position = Vector2i(0, 24)
-size = Vector2i(949, 477)
-popup_window = true
-theme = ExtResource("5")
-ok_button_text = "Open"
-file_mode = 0
-access = 2
-script = ExtResource("6")
-
-[node name="WarningPopup" type="AcceptDialog" parent="."]
-unique_name_in_owner = true
-handle_input_locally = false
-size = Vector2i(608, 346)
-popup_window = true
-content_scale_size = Vector2i(608, 346)
-content_scale_mode = 1
-content_scale_aspect = 4
-theme = ExtResource("5")
-
-[node name="WarningLabel" type="Label" parent="WarningPopup"]
-unique_name_in_owner = true
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 8.0
-offset_top = 8.0
-offset_right = -8.0
-offset_bottom = -48.0
-text = "
-"
-horizontal_alignment = 1
-vertical_alignment = 1
-autowrap_mode = 3
-clip_text = true
-text_overrun_behavior = 3
 
 [node name="Keyboard" type="PopupPanel" parent="."]
 unique_name_in_owner = true
@@ -112,7 +72,3 @@ script = ExtResource("9_5ltce")
 
 [connection signal="about_to_popup" from="ConfigPopup" to="." method="opened_popup"]
 [connection signal="popup_hide" from="ConfigPopup" to="." method="closed_popup"]
-[connection signal="about_to_popup" from="FileSystemPopup" to="." method="opened_popup"]
-[connection signal="about_to_popup" from="FileSystemPopup" to="FileSystemPopup" method="_on_about_to_popup"]
-[connection signal="close_requested" from="FileSystemPopup" to="FileSystemPopup" method="restore_window_focus"]
-[connection signal="focus_exited" from="FileSystemPopup" to="FileSystemPopup" method="restore_window_focus"]


### PR DESCRIPTION
With keyboard/controller input, focus was not being restored to the config panel after any modal dialogue (scraper, file dialog, warning popup)