### PR TITLE
Fix usability issues with OSK

### DIFF
--- a/addons/onscreenkeyboard/plugin_node.gd
+++ b/addons/onscreenkeyboard/plugin_node.gd
@@ -4,7 +4,7 @@ extends EditorPlugin
 func _enter_tree():
 	# Initialization of the plugin goes here
 	# Add the new type with a name, a parent type, a script and an icon
-	add_custom_type("OnscreenKeyboard", "PopupPanel", preload("onscreen_keyboard.gd"), preload("control_icon.png"))
+	add_custom_type("OnscreenKeyboard", "Window", preload("onscreen_keyboard.gd"), preload("control_icon.png"))
 
 func _exit_tree():
 	# Clean-up of the plugin goes here

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="RetroHub"
 run/main_scene="res://scenes/root/Root.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 boot_splash/bg_color=Color(0.188235, 0.235294, 0.290196, 1)
 boot_splash/image="res://assets/icons/app/splash.png"
 config/icon="res://icon.png"

--- a/scenes/root/Root.gd
+++ b/scenes/root/Root.gd
@@ -19,7 +19,8 @@ func _enter_tree():
 
 func _raw_input(event: InputEvent):
 	if not RetroHub._running_game:
-		if event.is_action_pressed("rh_menu") and not RetroHubConfig.config.is_first_time:
+		if event.is_action_pressed("rh_menu") and not RetroHubConfig.config.is_first_time \
+			and not RetroHubUI.is_virtual_keyboard_visible():
 			if not $ConfigPopup.visible:
 				get_viewport().set_input_as_handled()
 				$ConfigPopup.open_config()
@@ -35,6 +36,7 @@ func _ready():
 	RetroHubConfig.config_updated.connect(_on_config_updated)
 
 	# Add popups to UI singleton
+	RetroHubUI._n_theme_viewport = n_viewport
 	RetroHubUI._n_config_popup = n_config_popup
 	RetroHubUI._n_virtual_keyboard = n_keyboard_popup
 

--- a/scenes/root/Root.tscn
+++ b/scenes/root/Root.tscn
@@ -58,7 +58,7 @@ handle_input_locally = false
 visible = false
 content_scale_aspect = 4
 
-[node name="Keyboard" type="PopupPanel" parent="."]
+[node name="Keyboard" type="Window" parent="."]
 unique_name_in_owner = true
 position = Vector2i(0, 348)
 size = Vector2i(1152, 300)

--- a/source/UI.gd
+++ b/source/UI.gd
@@ -1,7 +1,8 @@
 extends Control
 
+var _n_theme_viewport : Viewport
 var _n_filesystem_popup : FileDialog: set = _set_filesystem_popup
-var _n_virtual_keyboard : PopupPanel: set = _set_virtual_keyboard
+var _n_virtual_keyboard : Window: set = _set_virtual_keyboard
 var _n_config_popup : Window: set = _set_config_popup
 var _n_warning_popup : AcceptDialog: set = _set_warning_popup
 
@@ -60,7 +61,7 @@ func _set_filesystem_popup(popup: FileDialog):
 	#warning-ignore:return_value_discarded
 	_n_filesystem_popup.visibility_changed.connect(_on_visibility_changed)
 
-func _set_virtual_keyboard(keyboard: PopupPanel):
+func _set_virtual_keyboard(keyboard: Window):
 	_n_virtual_keyboard = keyboard
 
 func _set_config_popup(config_popup: Window):
@@ -150,7 +151,7 @@ func show_warning(text: String):
 		_n_warning_popup.get_ok_button().grab_focus()
 
 func get_focused_window() -> Window:
-	var win_id := DisplayServer.get_focused_window_or_popup()
+	var win_id := DisplayServer.get_top_popup_or_focused_window()
 	var win : Window = instance_from_id(win_id)
 	return win
 
@@ -162,9 +163,13 @@ func get_true_focused_control() -> Control:
 
 	# Find currently focused "embedded" window viewport
 	var viewport := win.get_viewport()
+	# Handle theme viewport as well
+	if viewport == get_tree().get_root().get_viewport():
+		viewport = _n_theme_viewport
+
 	while viewport:
-		if viewport.get_focused_window_or_popup() == null:
+		if viewport.get_top_popup_or_focused_window() == null:
 			# Found the innermost viewport
 			return viewport.gui_get_focus_owner()
-		viewport = viewport.get_focused_window_or_popup().get_viewport()
+		viewport = viewport.get_top_popup_or_focused_window().get_viewport()
 	return get_viewport().gui_get_focus_owner()


### PR DESCRIPTION
- Refocus last viewport after keyboard is closed (restores focus to config popup).
- Back button was closing OSK instead of inserting backspaces.
- Update Godot fork to fix issues with fetching focused popup.
  - (Godot was updated to 4.2.dev4) 