### PR TITLE
Fix ScreenScraper scraping not working on search

### DIFF
--- a/source/scraper/ScreenScraperScraper.gd
+++ b/source/scraper/ScreenScraperScraper.gd
@@ -418,7 +418,7 @@ func scrape_game_by_hash(game_data: RetroHubGameData, type: int = RequestDetails
 
 	var http_client := HTTPClient.new()
 
-	var req := _new_request_details(game_data)
+	var req : RequestDetails = await _new_request_details(game_data)
 	req.type = type
 	req.url = "https://www.screenscraper.fr/api2/jeuInfos.php?" + http_client.query_string_from_dict(header_data)
 	req.data = md5
@@ -447,7 +447,7 @@ func scrape_game_by_search(game_data: RetroHubGameData, search_term: String, typ
 
 	var http_client := HTTPClient.new()
 
-	var req := _new_request_details(game_data)
+	var req : RequestDetails = await _new_request_details(game_data)
 	req.type = type
 	req.url = "https://www.screenscraper.fr/api2/jeuRecherche.php?" + http_client.query_string_from_dict(header_data)
 	return OK
@@ -498,7 +498,7 @@ func scrape_media(game_data: RetroHubGameData, media_type: int) -> int:
 	#warning-ignore:return_value_discarded
 	_req_semaphore.wait()
 
-	var req := _new_request_details(game_data)
+	var req : RequestDetails = await _new_request_details(game_data)
 	req.type = RequestDetails.Type.MEDIA
 	req.url = res["url"]
 	req.data = {"format": res["format"], "type": media_type}
@@ -510,7 +510,7 @@ func scrape_media_from_search(orig_game_data: RetroHubGameData, search_game_data
 		#warning-ignore:return_value_discarded
 		_cached_search_data.erase(orig_game_data)
 
-	return scrape_media(orig_game_data, media_type)
+	return await scrape_media(orig_game_data, media_type)
 
 func scrape_completed(game_data: RetroHubGameData) -> void:
 	#warning-ignore:return_value_discarded


### PR DESCRIPTION
`RequestDetails` needs to be added to the scene tree, which is deferred. So, we need to await it's addition before performing requests, otherwise there's a race condition.

This problem ocurred mainly on search requests because the request was immediate. Hash requests took some time before starting due to hashing the game files.