### PR TITLE
Fix tabs input on left shoulder not focusing elements properly

### DIFF
--- a/scenes/root/Root.tscn
+++ b/scenes/root/Root.tscn
@@ -62,6 +62,7 @@ content_scale_aspect = 4
 unique_name_in_owner = true
 position = Vector2i(0, 648)
 size = Vector2i(1152, 300)
+visible = false
 always_on_top = true
 theme = ExtResource("5")
 script = ExtResource("2")

--- a/source/utils/TabContainerHandler.gd
+++ b/source/utils/TabContainerHandler.gd
@@ -38,6 +38,7 @@ func _input(event):
 			(_focused and event.is_action_pressed("ui_left")):
 			if is_key_event_on_text(event):
 				return
+			get_viewport().set_input_as_handled()
 			if tab.current_tab > 0:
 				tab.current_tab -= 1
 			else:


### PR DESCRIPTION
This missing event handled call made left input on tabs keep propagating, creating weird behaviors.