### PR TITLE
Add custom gamemedia dir in first time setup

### DIFF
--- a/scenes/popups/first_time/GamesSection.gd
+++ b/scenes/popups/first_time/GamesSection.gd
@@ -5,10 +5,19 @@ signal advance_section
 @onready var n_intro_lbl := %IntroLabel
 @onready var n_path := %Path
 @onready var n_choose_dir := %ChooseDir
+@onready var n_custom_media_container := %CustomMediaContainer
+@onready var n_use_custom_media := %UseCustomMedia
+@onready var n_media_path := %MediaPath
+@onready var n_media_choose_dir := %MediaChooseDir
+@onready var n_media_warning_empty := %MediaWarningEmpty
+
 @onready var n_next_button := %NextButton
 
 func _ready():
 	set_path(RetroHubConfig.config.games_dir)
+	set_media_path(RetroHubConfig.config.custom_gamemedia_dir)
+	n_use_custom_media.set_pressed_no_signal(RetroHubConfig.config.custom_gamemedia_dir.is_empty())
+	_on_use_custom_media_toggled(n_use_custom_media.button_pressed)
 
 func grab_focus():
 	if RetroHubConfig.config.accessibility_screen_reader_enabled:
@@ -18,6 +27,7 @@ func grab_focus():
 
 func _on_NextButton_pressed():
 	RetroHubConfig.config.games_dir = n_path.text
+	RetroHubConfig.config.custom_gamemedia_dir = n_media_path.text if not n_use_custom_media.button_pressed else ""
 	RetroHubConfig.load_game_data_files()
 	emit_signal("advance_section")
 
@@ -28,4 +38,31 @@ func _on_ChooseDir_pressed():
 func set_path(path: String):
 	if not path.is_empty():
 		n_path.text = path
-	n_next_button.disabled = n_path.text.is_empty()
+	query_next_btn()
+
+func _on_use_custom_media_toggled(toggled_on: bool):
+	n_custom_media_container.visible = not toggled_on
+	check_empty_media()
+	query_next_btn()
+
+func check_empty_media():
+	if n_use_custom_media.button_pressed:
+		n_media_warning_empty.visible = false
+		return
+	var dir := DirAccess.open(n_media_path.text)
+	dir.include_navigational = false
+	n_media_warning_empty.visible = not (dir.get_files().is_empty() and dir.get_directories().is_empty())
+
+func query_next_btn():
+	n_next_button.disabled = n_path.text.is_empty() or \
+		(not n_use_custom_media.button_pressed and (n_media_path.text.is_empty() or not DirAccess.dir_exists_absolute(n_media_path.text)))
+
+func _on_media_choose_dir_pressed():
+	RetroHubUI.request_folder_load(n_media_path.text)
+	set_media_path(await RetroHubUI.path_selected)
+
+func set_media_path(path: String):
+	if not path.is_empty():
+		n_media_path.text = path
+	check_empty_media()
+	query_next_btn()

--- a/scenes/popups/first_time/GamesSection.tscn
+++ b/scenes/popups/first_time/GamesSection.tscn
@@ -50,6 +50,59 @@ focus_neighbor_top = NodePath("../../NextButton")
 text = "Choose directory"
 icon = ExtResource("2")
 
+[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer2"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Store downloaded media in the configuration directory?"
+
+[node name="UseCustomMedia" type="CheckButton" parent="VBoxContainer/HBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+button_pressed = true
+
+[node name="CustomMediaContainer" type="MarginContainer" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/margin_left = 3
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 3
+
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/CustomMediaContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="VBoxContainer/CustomMediaContainer/VBoxContainer"]
+layout_mode = 2
+text = "Game media location"
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/CustomMediaContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 15
+
+[node name="MediaPath" type="LineEdit" parent="VBoxContainer/CustomMediaContainer/VBoxContainer/HBoxContainer3"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+focus_mode = 0
+placeholder_text = "<empty>"
+editable = false
+
+[node name="MediaChooseDir" type="Button" parent="VBoxContainer/CustomMediaContainer/VBoxContainer/HBoxContainer3"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_neighbor_top = NodePath("../../../../NextButton")
+text = "Choose directory"
+icon = ExtResource("2")
+
+[node name="MediaWarningEmpty" type="RichTextLabel" parent="VBoxContainer/CustomMediaContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+bbcode_enabled = true
+text = "[img]assets/icons/warning.svg[/img] The selected directory isn't currently empty."
+fit_content = true
+
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
 layout_mode = 2
 
@@ -60,7 +113,7 @@ text = "This directory will contain all your games. It has a special structure: 
  
 To add games, simply create the system folder if it doesn't exist (either from RetroHub in the next section or manually) and drop your games inside it.
  
-RetroHub will automatically filter files based on common extensions per system and _recognize your game files. This is configurable per system if tweaks are needed."
+RetroHub will automatically filter files based on common extensions per system and recognize your game files. This is configurable per system if tweaks are needed."
 autowrap_mode = 2
 
 [node name="AccessibilityFocus" type="Node" parent="VBoxContainer/Label2"]
@@ -74,4 +127,6 @@ disabled = true
 text = "Next"
 
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/ChooseDir" to="." method="_on_ChooseDir_pressed"]
+[connection signal="toggled" from="VBoxContainer/HBoxContainer2/UseCustomMedia" to="." method="_on_use_custom_media_toggled"]
+[connection signal="pressed" from="VBoxContainer/CustomMediaContainer/VBoxContainer/HBoxContainer3/MediaChooseDir" to="." method="_on_media_choose_dir_pressed"]
 [connection signal="pressed" from="VBoxContainer/NextButton" to="." method="_on_NextButton_pressed"]

--- a/source/Config.gd
+++ b/source/Config.gd
@@ -721,4 +721,6 @@ func get_gamelists_dir() -> String:
 	return get_config_dir() + "/gamelists"
 
 func get_gamemedia_dir() -> String:
+	if not config.custom_gamemedia_dir.is_empty():
+		return config.custom_gamemedia_dir
 	return get_config_dir() + "/gamemedia"

--- a/source/data/ConfigData.gd
+++ b/source/data/ConfigData.gd
@@ -35,6 +35,7 @@ var virtual_keyboard_type : String = ConfigData.default_virtual_keyboard_type():
 var virtual_keyboard_show_on_controller : bool = true: set = _set_virtual_keyboard_show_on_controller
 var virtual_keyboard_show_on_mouse : bool = false: set = _set_virtual_keyboard_show_on_mouse
 var accessibility_screen_reader_enabled : bool = true: set = _set_accessibility_screen_reader_enabled
+var custom_gamemedia_dir : String = "": set = _set_custom_gamemedia_dir
 
 const KEY_CONFIG_VERSION = "config_version"
 const KEY_IS_FIRST_TIME = "is_first_time"
@@ -64,6 +65,7 @@ const KEY_VIRTUAL_KEYBOARD_TYPE = "virtual_keyboard_type"
 const KEY_VIRTUAL_KEYBOARD_SHOW_ON_CONTROLLER = "virtual_keyboard_show_on_controller"
 const KEY_VIRTUAL_KEYBOARD_SHOW_ON_MOUSE = "virtual_keyboard_show_on_mouse"
 const KEY_ACCESSIBILITY_SCREEN_READER_ENABLED = "accessibility_screen_reader_enabled"
+const KEY_CUSTOM_GAMEMEDIA_DIR = "custom_gamemedia_dir"
 
 
 const _keys = [
@@ -94,7 +96,8 @@ const _keys = [
 	KEY_VIRTUAL_KEYBOARD_TYPE,
 	KEY_VIRTUAL_KEYBOARD_SHOW_ON_CONTROLLER,
 	KEY_VIRTUAL_KEYBOARD_SHOW_ON_MOUSE,
-	KEY_ACCESSIBILITY_SCREEN_READER_ENABLED
+	KEY_ACCESSIBILITY_SCREEN_READER_ENABLED,
+	KEY_CUSTOM_GAMEMEDIA_DIR
 ]
 
 var _should_save : bool = true
@@ -295,6 +298,10 @@ func _set_virtual_keyboard_show_on_mouse(_virtual_keyboard_show_on_mouse):
 func _set_accessibility_screen_reader_enabled(_accessibility_screen_reader_enabled):
 	mark_for_saving()
 	accessibility_screen_reader_enabled = _accessibility_screen_reader_enabled
+
+func _set_custom_gamemedia_dir(_custom_gamemedia_dir):
+	mark_for_saving()
+	custom_gamemedia_dir = _custom_gamemedia_dir
 
 func mark_for_saving():
 	if _should_save:


### PR DESCRIPTION
Closes #295

Allows setting a custom directory for the downloaded game media. This was added to the first time setup wizard.

![image](https://github.com/retrohub-org/retrohub/assets/6501975/8bf0a369-368f-4962-ac8c-03dc3abd5f53)
