### PR TITLE
Add support for obtaining box texture regions

### DIFF
--- a/source/Media.gd
+++ b/source/Media.gd
@@ -372,3 +372,51 @@ func compute_blurhash(game_data: RetroHubGameData) -> void:
 	FileUtils.ensure_path(file_path)
 	JSONUtils.save_json_file(json_data, file_path)
 
+func get_box_texture_region(data: RetroHubGameData, media: RetroHubGameMediaData, type: RetroHubGameData.BoxTextureRegions, rotate: bool = true) -> Texture2D:
+	if not data.box_texture_regions.has(type) or not media.box_texture:
+		return null
+
+	var coords_raw : Rect2 = data.box_texture_regions[type]
+	var _offset_1 := coords_raw.position
+	var _offset_2 := coords_raw.size
+
+	var offset : Vector2
+	var size : Vector2
+	var rotation : int = 0
+
+	# Coords embed text direction. We infer it by the xy ordering of both coords.
+	# 90 degrees (text up-to-down)
+	if _offset_1.x >= _offset_2.x and _offset_1.y < _offset_2.y:
+		offset = Vector2(_offset_2.x, _offset_1.y)
+		size = Vector2(_offset_1.x, _offset_2.y) - offset
+		rotation = 90
+	# 180 degrees (text right-to-left)
+	elif _offset_1.x >= _offset_2.x and _offset_1.y >= _offset_2.y:
+		offset = Vector2(_offset_2.x, _offset_2.y)
+		size = Vector2(_offset_1.x, _offset_1.y) - offset
+		rotation = 180
+	# -90 degrees (text down-to-up)
+	elif _offset_1.x < _offset_2.x and _offset_1.y >= _offset_2.y:
+		offset = Vector2(_offset_1.x, _offset_2.y)
+		size = Vector2(_offset_2.x, _offset_1.y) - offset
+		rotation = -90
+	else:
+		offset = Vector2(_offset_1.x, _offset_1.y)
+		size = Vector2(_offset_2.x, _offset_2.y) - offset
+
+	var image := media.box_texture.get_image()
+	var image_size := Vector2(image.get_width(), image.get_height())
+	var offset_i := Vector2i((offset * image_size).round())
+	var size_i := Vector2i((size * image_size).round())
+	var blit_image := Image.create(size_i.x, size_i.y, false, image.get_format())
+	blit_image.blit_rect(image, Rect2i(offset_i, size_i), Vector2i.ZERO)
+	if rotate:
+		match rotation:
+			-90:
+				blit_image.rotate_90(CLOCKWISE)
+			90:
+				blit_image.rotate_90(COUNTERCLOCKWISE)
+			180:
+				blit_image.rotate_180()
+
+	return ImageTexture.create_from_image(blit_image)

--- a/source/data/GameData.gd
+++ b/source/data/GameData.gd
@@ -1,6 +1,12 @@
 extends Resource
 class_name RetroHubGameData
 
+enum BoxTextureRegions {
+	BACK,
+	SPINE,
+	FRONT,
+}
+
 # Sorter function
 static func sort(a: RetroHubGameData, b: RetroHubGameData):
 	return a.name.naturalnocasecmp_to(b.name) == -1
@@ -24,6 +30,7 @@ func copy_from(other: RetroHubGameData) -> void:
 	play_count = other.play_count
 	last_played = other.last_played
 	emulator = other.emulator
+	box_texture_regions = other.box_texture_regions.duplicate()
 
 ## Whether this game already has metadata; if it doesn't, you should
 ## present a much simpler view of it
@@ -88,3 +95,8 @@ var last_played : String
 ## Custom emulator to run this game on, overriding default values.
 ## If non-empty, specifies a valid emulator name
 var emulator : String
+
+## Information about box texture regions. This is a dictionary of
+## Rect2 dimensions, with range [0.0 , 1.0] delimiting the regions of the box texture.
+## (use `RetroHubMedia.get_box_texture_region` to fetch the region's sub-Texture)
+var box_texture_regions : Dictionary = {}

--- a/source/scraper/ScreenScraperScraper.gd
+++ b/source/scraper/ScreenScraperScraper.gd
@@ -361,10 +361,253 @@ func _process_req_data(req: RequestDetails, game_data: RetroHubGameData):
 
 			call_thread_safe("emit_signal", "game_scrape_multiple_available", game_data, details)
 
-func _process_req_media(req: RequestDetails, game_data):
+func _process_req_media(req: RequestDetails, game_data: RetroHubGameData):
 	var extension : String = req.data["format"]
 	var type : int = req.data["type"]
 	call_thread_safe("emit_signal", "media_scrape_finished", game_data, type, req._req_body, extension)
+
+static func _process_box_texture_regions(game_data: RetroHubGameData):
+	var region := RetroHubConfig.config.region
+	match game_data.system.name:
+		# Systems with world-wide packaging first
+		"amiga", "amiga600":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 1.0, 0.458047945, 0.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.54109589, 0.0, 0.45890411, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(1.0, 0.0, 0.541952055, 1.0)
+		"amiga1200", "apple2", "atarist", "pc88", "pc98", "spectravideo", "ti99", \
+		"lutro", "openbor", "pico8", "solarus", "atarijaguar", "channelf", "n64", \
+		"odyssey2", "wonderswan", "wonderswancolor", "atomiswave", "daphne", \
+		"naomi", "naomigd", "neogeo":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 1.0, 0.455045872, 0.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.544036697, 0.0, 0.455963303, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(1.0, 0.0, 0.544954128, 1.0)
+		"amigacd32", "cdtv", "neogeocd", "tg-cd":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.488286067, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.511097411, 0.0, 0.488902589, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.581381011, 0.0, 1.0, 1.0)
+		"amstradcpc", "moto", "msx", "msx2", "msxturbor", "to8", "x1", "x68000", \
+		"genesis", "sega32x", "mastersystem":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.454288407, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.543826579, 0.0, 0.455230914, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.544769086, 0.0, 1.0, 1.0)
+		"atari800", "atari2600", "atari5200", "atari7800", "atarixe", "colecovision", \
+		"intellivision":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.455963303, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.544954128, 0.0, 0.456880734, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.54587156, 0.0, 1.0, 1.0)
+		"bbcmicro", "c64", "dragon32", "oric", "tanodragon":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.473127753, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.526872247, 0.0, 0.474008811, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.527753304, 0.0, 1.0, 1.0)
+		"coco", "trs-80", "pokemini":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.46728972, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.53271028, 0.0, 0.467957276, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.533377837, 0.0, 1.0, 1.0)
+		"dos", "palm", "pc", "samcoupe", "scummvm":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.471559633, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.526605505, 0.0, 0.472477064, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.527522936, 0.0, 1.0, 1.0)
+		"vic20", "zx81", "zxspectrum":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.441409692, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.557709251, 0.0, 0.442290749, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.558590308, 0.0, 1.0, 1.0)
+		"tic80", "uzebox":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 1.0, 0.45158371, 0.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.547511312, 0.0, 0.452488688, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(1.0, 0.0, 0.54841629, 1.0)
+		"arcade", "astrocade", "vectrex":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.455045872, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.544036697, 0.0, 0.455963303, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.544954128, 0.0, 1.0, 1.0)
+		"atarijaguarcd", "gc", "ps2", "xbox", "psvita", "wii", "wiiu", "xbox360":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.471679688, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.525390625, 0.0, 0.47265625, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.526367188, 0.0, 1.0, 1.0)
+		"atarilynx":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.456931911, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.545529122, 0.0, 0.457752256, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.546349467, 0.0, 1.0, 1.0)
+		"cdimono1":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.524850895, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.549370444, 0.0, 0.525513585, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.550033135, 0.0, 1.0, 1.0)
+		"fds":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(1.0, 0.395884774, 0.0, 0.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(1.0, 0.436213992, 0.0, 0.396707819)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.0, 0.437037037, 1.0, 1.0)
+		"gameandwatch":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.446601942, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.552184466, 0.0, 0.447815534, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.553398058, 0.0, 1.0, 1.0)
+		"64dd":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.476614699, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.524870082, 0.0, 0.47735709, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.525612472, 0.0, 1.0, 1.0)
+		"gx4000":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.43984375, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.56015625, 0.0, 0.440625, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.5609375, 0.0, 1.0, 1.0)
+		"multivision", "sg-1000":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.469077069, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.531874405, 0.0, 0.470028544, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.53282588, 0.0, 1.0, 1.0)
+		"nds", "virtualboy", "n3ds":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.470642202, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.529357798, 0.0, 0.471559633, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.530275229, 0.0, 1.0, 1.0)
+		"ngpc":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.446856287, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.551646707, 0.0, 0.44760479, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.55239521, 0.0, 1.0, 1.0)
+		"satellaview", "sufami":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.437614679, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.563302752, 0.0, 0.43853211, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.564220183, 0.0, 1.0, 1.0)
+		"supergrafx":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.481238274, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.518761726, 0.0, 0.48217636, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.519699812, 0.0, 1.0, 1.0)
+		"ps3":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.472222222, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.525326797, 0.0, 0.473039216, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.526143791, 0.0, 1.0, 1.0)
+		"psp":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.464159812, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.533490012, 0.0, 0.4653349, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.5346651, 0.0, 1.0, 1.0)
+		"switch":
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.476244344, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.523755656, 0.0, 0.477375566, 1.0)
+			game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.524886878, 0.0, 1.0, 1.0)
+		# Systems with region-specific packaging
+		"3do":
+			match region:
+				"eur":
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.488286067, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.511097411, 0.0, 0.488902589, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.511713933, 0.0, 1.0, 1.0)
+				"jpn":
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.488286067, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.511097411, 0.0, 0.488902589, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.581381011, 0.0, 1.0, 1.0)
+				"usa", _:
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.458385093, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.540372671, 0.0, 0.459627329, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.541614907, 0.0, 1.0, 1.0)
+		"dreamcast":
+			if region == "eur":
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.506125081, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.561573179, 0.0, 0.506769826, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.562217924, 0.0, 1.0, 1.0)
+			else:
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.524850895, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.549370444, 0.0, 0.525513585, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.550033135, 0.0, 1.0, 1.0)
+		"gamegear":
+			if region == "jpn":
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.456153846, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.545384615, 0.0, 0.456923077, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.546153846, 0.0, 1.0, 1.0)
+			else:
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.455963303, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.544954128, 0.0, 0.456880734, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.54587156, 0.0, 1.0, 1.0)
+		"gb", "gbc", "gba":
+			if region == "jpn":
+				if game_data.system.name == "gba":
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 1.0, 0.446673706, 0.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.553326294, 0.0, 0.447729673, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(1.0, 0.0, 0.55438226, 1.0)
+				else:
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.45123839, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.547987616, 0.0, 0.452012384, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.54876161, 0.0, 1.0, 1.0)
+			else:
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.46728972, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.53271028, 0.0, 0.467957276, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.533377837, 0.0, 1.0, 1.0)
+		"segacd":
+			match region:
+				"jpn":
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.488286067, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.511097411, 0.0, 0.488902589, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.581381011, 0.0, 1.0, 1.0)
+				"eur":
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.477870813, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.520933014, 0.0, 0.4784689, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.5215311, 0.0, 1.0, 1.0)
+				"usa", _:
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.465820313, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.530273438, 0.0, 0.466796875, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.53125, 0.0, 1.0, 1.0)
+		"nes":
+			if region == "jpn":
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.455045872, 0.0, 0.0, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.544036697, 0.0, 0.455963303, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.544954128, 1.0, 1.0, 0.0)
+			else:
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 1.0, 0.455045872, 0.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.544036697, 0.0, 0.455963303, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(1.0, 0.0, 0.544954128, 1.0)
+		"ngp":
+			if region == "jpn":
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.446856287, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.551646707, 0.0, 0.44760479, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.55239521, 0.0, 1.0, 1.0)
+			else:
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.472477064, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.530275229, 0.0, 0.473394495, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.531192661, 0.0, 1.0, 1.0)
+		"tg16":
+			if region == "jpn":
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.488286067, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.511097411, 0.0, 0.488902589, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.581381011, 0.0, 1.0, 1.0)
+			else:
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.471559633, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.526605505, 0.0, 0.472477064, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.527522936, 0.0, 1.0, 1.0)
+		"pcfx":
+			if region == "jpn":
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.507284768, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.549006623, 0.0, 0.50794702, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.549668874, 0.0, 1.0, 1.0)
+			else:
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.454288407, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.543826579, 0.0, 0.455230914, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.544769086, 0.0, 1.0, 1.0)
+		"psx":
+			match region:
+				"jpn":
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.524850895, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.549370444, 0.0, 0.525513585, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.550033135, 0.0, 1.0, 1.0)
+				"eur":
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.507284768, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.549006623, 0.0, 0.50794702, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.549668874, 0.0, 1.0, 1.0)
+				"usa", _:
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.488286067, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.511097411, 0.0, 0.488902589, 1.0)
+					game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.511713933, 0.0, 1.0, 1.0)
+		"saturn":
+			if region == "eur":
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.465820313, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.530273438, 0.0, 0.466796875, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.53125, 0.0, 1.0, 1.0)
+			else:
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.524850895, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.549370444, 0.0, 0.525513585, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.550033135, 0.0, 1.0, 1.0)
+		"snes":
+			if region == "jpn":
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 0.0, 0.437614679, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.563302752, 0.0, 0.43853211, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(0.564220183, 0.0, 1.0, 1.0)
+			else:
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.BACK] = Rect2(0.0, 1.0, 0.455045872, 0.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.SPINE] = Rect2(0.544036697, 0.0, 0.455963303, 1.0)
+				game_data.box_texture_regions[RetroHubGameData.BoxTextureRegions.FRONT] = Rect2(1.0, 0.0, 0.544954128, 1.0)
 
 func _new_request_details(game_data: RetroHubGameData) -> RequestDetails:
 	var req := RequestDetails.new()
@@ -587,6 +830,8 @@ func _process_raw_game_data(json: Dictionary, game_data: RetroHubGameData):
 		if not "-" in players:
 			players = players + "-" + players
 		game_data.num_players = players
+
+	_process_box_texture_regions(game_data)
 
 func extract_json_date(date: String) -> String:
 	var splits := date.split("-")

--- a/tests/box_texture_blit.tscn
+++ b/tests/box_texture_blit.tscn
@@ -1,0 +1,195 @@
+[gd_scene load_steps=3 format=3 uid="uid://cnbfn5gitdk7g"]
+
+[ext_resource type="Texture2D" uid="uid://dydir8kskmsc6" path="res://assets/icons/load.svg" id="1_biy6p"]
+
+[sub_resource type="GDScript" id="GDScript_my60v"]
+script/source = "extends Control
+
+var game_data_path : String
+var game_data : RetroHubGameData
+var media_data : RetroHubGameMediaData
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	$FileDialog.current_dir = RetroHubConfig.get_gamelists_dir()
+	RetroHubConfig.load_user_data()
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+func handle_tex():
+	if game_data_path.is_empty() or not FileAccess.file_exists(game_data_path): return
+
+	var data : Dictionary = JSONUtils.load_json_file(game_data_path)
+	if data.is_empty():
+		printerr(\"Error loading data!\")
+		return
+	else:
+		game_data = RetroHubGameData.new()
+		game_data.path = game_data_path
+		game_data.system = RetroHubConfig.systems[game_data_path.get_base_dir().get_file()]
+		game_data.system_path = game_data.system.name
+		game_data.has_metadata = true
+		game_data.has_media = true
+		if data.has(\"box_texture_regions\"):
+			for key in data[\"box_texture_regions\"]:
+				var region_data : PackedFloat64Array = data[\"box_texture_regions\"][key].split_floats(\";\")
+				if region_data.size() < 4: continue
+				var keys = RetroHubGameData.BoxTextureRegions.keys()
+				var key_idx : int = RetroHubGameData.BoxTextureRegions.keys().find(key.to_upper())
+				if key_idx == -1:
+					key_idx = int(key)
+				game_data.box_texture_regions[key_idx] = Rect2(region_data[0], region_data[1], region_data[2], region_data[3])
+		media_data = RetroHubMedia.retrieve_media_data(game_data, RetroHubMedia.Type.BOX_TEXTURE)
+		%RawTex.texture = media_data.box_texture
+
+func _on_file_dialog_file_selected(path):
+	game_data_path = path
+	handle_tex()
+
+
+func _on_load_pressed():
+	$FileDialog.popup()
+
+
+func _on_reload_pressed():
+	_on_file_dialog_file_selected(game_data_path)
+
+
+func _on_front_pressed():
+	%CompTex.texture = RetroHubMedia.get_box_texture_region(game_data, media_data, RetroHubGameData.BoxTextureRegions.FRONT)
+
+
+func _on_spine_pressed():
+	%CompTex.texture = RetroHubMedia.get_box_texture_region(game_data, media_data, RetroHubGameData.BoxTextureRegions.SPINE)
+
+
+func _on_back_pressed():
+	%CompTex.texture = RetroHubMedia.get_box_texture_region(game_data, media_data, RetroHubGameData.BoxTextureRegions.BACK)
+"
+
+[node name="Control" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = SubResource("GDScript_my60v")
+
+[node name="Load" type="Button" parent="."]
+unique_name_in_owner = true
+layout_mode = 0
+offset_right = 8.0
+offset_bottom = 8.0
+text = "Load gamedata"
+icon = ExtResource("1_biy6p")
+
+[node name="Reload" type="Button" parent="."]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 164.0
+offset_right = 287.0
+offset_bottom = 31.0
+text = "Reload"
+icon = ExtResource("1_biy6p")
+
+[node name="Back" type="Button" parent="."]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 58.0
+offset_top = 163.0
+offset_right = 181.0
+offset_bottom = 194.0
+text = "Back"
+icon = ExtResource("1_biy6p")
+
+[node name="Spine" type="Button" parent="."]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 58.0
+offset_top = 209.0
+offset_right = 181.0
+offset_bottom = 240.0
+text = "Spine"
+icon = ExtResource("1_biy6p")
+
+[node name="Front" type="Button" parent="."]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 58.0
+offset_top = 254.0
+offset_right = 181.0
+offset_bottom = 285.0
+text = "Front"
+icon = ExtResource("1_biy6p")
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 0
+offset_left = 326.0
+offset_top = 3.0
+offset_right = 366.0
+offset_bottom = 26.0
+text = "Raw:"
+
+[node name="RawTex" type="TextureRect" parent="Label"]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 204.0
+offset_top = 1.0
+offset_right = 824.0
+offset_bottom = 276.0
+expand_mode = 1
+stretch_mode = 5
+
+[node name="Panel" type="Panel" parent="Label/RawTex"]
+show_behind_parent = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Label2" type="Label" parent="."]
+layout_mode = 0
+offset_left = 326.0
+offset_top = 310.0
+offset_right = 366.0
+offset_bottom = 333.0
+text = "Blit:"
+
+[node name="CompTex" type="TextureRect" parent="Label2"]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 204.0
+offset_top = 1.0
+offset_right = 824.0
+offset_bottom = 276.0
+expand_mode = 1
+stretch_mode = 5
+
+[node name="Panel" type="Panel" parent="Label2/CompTex"]
+show_behind_parent = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="FileDialog" type="FileDialog" parent="."]
+title = "Open a File"
+size = Vector2i(1030, 600)
+ok_button_text = "Open"
+file_mode = 0
+access = 2
+filters = PackedStringArray("*.json; Game data")
+
+[connection signal="pressed" from="Load" to="." method="_on_load_pressed"]
+[connection signal="pressed" from="Reload" to="." method="_on_reload_pressed"]
+[connection signal="pressed" from="Back" to="." method="_on_back_pressed"]
+[connection signal="pressed" from="Spine" to="." method="_on_spine_pressed"]
+[connection signal="pressed" from="Front" to="." method="_on_front_pressed"]
+[connection signal="file_selected" from="FileDialog" to="." method="_on_file_dialog_file_selected"]


### PR DESCRIPTION
This adds a dedicated field to indicate certain regions of the box texture as key areas, such as front cover.

For ScreenScraper, all these values were manually calculated.

Closes #296 