### PR TITLE
Fix PS3 media file names

### DIFF
--- a/scenes/popups/scraper/ScraperPopup.gd
+++ b/scenes/popups/scraper/ScraperPopup.gd
@@ -306,7 +306,7 @@ func t_on_media_scrape_finished(game_data: RetroHubGameData, type: int, data: Pa
 		var path := RetroHubConfig.get_gamemedia_dir() \
 						.path_join(game_data.system.name) \
 						.path_join(RetroHubMedia.convert_type_to_media_path(type)) \
-						.path_join(game_data.path.get_file().get_basename() + "." + extension)
+						.path_join(_get_game_path(game_data) + "." + extension)
 		FileUtils.ensure_path(path)
 		var file := FileAccess.open(path, FileAccess.WRITE)
 		if file:
@@ -327,6 +327,17 @@ func t_on_media_scrape_finished(game_data: RetroHubGameData, type: int, data: Pa
 		emit_signal("scrape_step", game_entry)
 		if game_entry.curr >= game_entry.total:
 			_finish_scrape(game_entry)
+
+func _get_game_path(game_data: RetroHubGameData) -> String:
+	if game_data.system.name == "ps3":
+		# PS3 games use PARAM.SFO as the game identifier. We need to use the folder name instead.
+		var path := game_data.path.get_base_dir()
+		while not path.is_empty():
+			if not path.ends_with("PS3_GAME"):
+				return path.get_file()
+			path = path.get_base_dir()
+
+	return game_data.path.get_file().get_basename()
 
 func t_on_media_scrape_not_found(game_data: RetroHubGameData, _type: int):
 	if pending_medias.has(game_data):

--- a/scenes/root/FileSystemPopup.gd
+++ b/scenes/root/FileSystemPopup.gd
@@ -84,6 +84,9 @@ func _ready():
 func _unhandled_input(event):
 	if RetroHub.is_input_echo() or not visible:
 		return
+	if event.is_action_pressed("ui_cancel") and event is InputEventKey \
+		and get_viewport().gui_get_focus_owner() is LineEdit:
+			get_viewport().set_input_as_handled()
 	if event is InputEventJoypadButton:
 		if event.is_action_released("rh_major_option"):
 			get_viewport().set_input_as_handled()


### PR DESCRIPTION
Fixes #294.

For PS3, the folder name is used as a unique identifier, due to RPCS3's enforced game structure.