### PR TITLE
Fix key input on TextEdit fields

### DIFF
--- a/scenes/config/GameMetadataEditor.tscn
+++ b/scenes/config/GameMetadataEditor.tscn
@@ -66,6 +66,7 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(300, 150)
 layout_mode = 2
 wrap_mode = 1
+caret_blink = true
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="ScrollContainer/VBoxContainer"]
 layout_mode = 2
@@ -288,19 +289,19 @@ script = ExtResource("7")
 
 [connection signal="text_changed" from="ScrollContainer/VBoxContainer/HBoxContainer/Name" to="." method="_on_change_ocurred"]
 [connection signal="text_changed" from="ScrollContainer/VBoxContainer/HBoxContainer2/Description" to="." method="_on_change_ocurred"]
-[connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer3/HBoxContainer/Rating" to="." method="_on_Rating_value_changed"]
 [connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer3/HBoxContainer/Rating" to="." method="_on_change_ocurred"]
+[connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer3/HBoxContainer/Rating" to="." method="_on_Rating_value_changed"]
 [connection signal="text_changed" from="ScrollContainer/VBoxContainer/HBoxContainer4/ReleaseDate" to="." method="_on_change_ocurred"]
 [connection signal="text_changed" from="ScrollContainer/VBoxContainer/HBoxContainer5/Developer" to="." method="_on_change_ocurred"]
 [connection signal="text_changed" from="ScrollContainer/VBoxContainer/HBoxContainer6/Publisher" to="." method="_on_change_ocurred"]
 [connection signal="item_selected" from="ScrollContainer/VBoxContainer/HBoxContainer12/AgeRating" to="." method="_on_change_ocurred"]
 [connection signal="text_changed" from="ScrollContainer/VBoxContainer/HBoxContainer7/Genres" to="." method="_on_change_ocurred"]
-[connection signal="toggled" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer/FixedPlayers" to="." method="_on_change_ocurred"]
 [connection signal="toggled" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer/FixedPlayers" to="." method="_on_FixedPlayers_toggled"]
-[connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer/FixedPlayersNum" to="." method="_on_change_ocurred"]
+[connection signal="toggled" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer/FixedPlayers" to="." method="_on_change_ocurred"]
 [connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer/FixedPlayersNum" to="." method="_on_FixedPlayersNum_value_changed"]
-[connection signal="toggled" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayers" to="." method="_on_change_ocurred"]
+[connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer/FixedPlayersNum" to="." method="_on_change_ocurred"]
 [connection signal="toggled" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayers" to="." method="_on_VariablePlayers_toggled"]
+[connection signal="toggled" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayers" to="." method="_on_change_ocurred"]
 [connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayersMin" to="." method="_on_change_ocurred"]
 [connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayersMin" to="." method="_on_VariablePlayersMin_value_changed"]
 [connection signal="value_changed" from="ScrollContainer/VBoxContainer/HBoxContainer8/VBoxContainer/HBoxContainer2/VariablePlayersMax" to="." method="_on_change_ocurred"]

--- a/source/utils/TabContainerHandler.gd
+++ b/source/utils/TabContainerHandler.gd
@@ -62,7 +62,7 @@ func _input(event):
 func is_key_event_on_text(event: InputEvent):
 	if event is InputEventKey:
 		var control := get_viewport().gui_get_focus_owner()
-		return (control is LineEdit or control is CodeEdit) and control.editable
+		return (control is LineEdit or control is TextEdit) and control.editable
 	return false
 
 func _on_tab_clicked(tab_idx: int):


### PR DESCRIPTION
Was mistakenly detecting `CodeEdit` instead of `TextEdit`.

Addresses one of the issues from #305 