### PR TITLE
Fix OSK not working in-app

### DIFF
--- a/addons/onscreenkeyboard/onscreen_keyboard.gd
+++ b/addons/onscreenkeyboard/onscreen_keyboard.gd
@@ -161,7 +161,8 @@ func _hideKeyboard(keyData=null,x=null,y=null,steal_focus=null):
 
 
 func _showKeyboard(keyData=null,x=null,y=null):
-	tweenOnTop = focused_control.get_global_transform_with_canvas().origin.y > bottomPos - size.y
+	var control_rect := focused_control.get_global_rect()
+	tweenOnTop = control_rect.position.y + control_rect.size.y > bottomPos - size.y - 30
 
 	var tween := create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_SINE)
 	if tweenOnTop:

--- a/scenes/config/ConfigPopup.gd
+++ b/scenes/config/ConfigPopup.gd
@@ -47,6 +47,7 @@ func _input(event: InputEvent):
 
 func open_config():
 	super.popup_centered_ratio(0.8)
+	grab_focus()
 	_on_ConfigPopup_about_to_show()
 
 func close():

--- a/scenes/root/Root.gd
+++ b/scenes/root/Root.gd
@@ -11,7 +11,6 @@ extends Control
 	ProjectSettings.get_setting("display/window/size/viewport_height")
 )
 
-var n_last_focused : Control
 var is_popup_open : bool = false
 
 func _enter_tree():
@@ -126,5 +125,3 @@ func closed_popup(popup: Window = null):
 	$DarkenOverlay.visible = false
 	set_theme_input_enabled(true)
 	is_popup_open = false
-	if is_instance_valid(n_last_focused):
-		n_last_focused.grab_focus()

--- a/source/UI.gd
+++ b/source/UI.gd
@@ -187,17 +187,14 @@ func get_true_focused_control() -> Control:
 	if win == null:
 		return get_viewport().gui_get_focus_owner()
 
-	# Find currently focused "embedded" window viewport
-	var viewport := win.get_viewport()
-	# Handle theme viewport as well
-	if viewport == get_tree().get_root().get_viewport():
-		viewport = _n_theme_viewport
-
-	while viewport:
-		if viewport.get_top_popup_or_focused_window() == null:
+	while win:
+		if win.get_top_popup_or_focused_window() == null:
 			# Found the innermost viewport
-			return viewport.gui_get_focus_owner()
-		viewport = viewport.get_top_popup_or_focused_window().get_viewport()
+			if win == $"/root":
+				return _n_theme_viewport.gui_get_focus_owner()
+			else:
+				return win.gui_get_focus_owner()
+		win = win.get_top_popup_or_focused_window()
 	return get_viewport().gui_get_focus_owner()
 
 func play_sound(key: AudioKeys, override : bool = true):


### PR DESCRIPTION
With upstream changes on the engine, the code logic to find the root window has changed, and prevented the OSK from working with any in-app config popup.