### PR TITLE
Cache emulator paths

### DIFF
--- a/scenes/config/settings/emulator/EmulatorEditor.gd
+++ b/scenes/config/settings/emulator/EmulatorEditor.gd
@@ -26,13 +26,15 @@ func set_curr_emulator(_curr_emulator: Dictionary):
 	n_logo.text = "<click to add>" if not n_logo.icon else ""
 	n_name.text = curr_emulator["name"]
 	n_fullname.text = curr_emulator["fullname"]
-	n_path.text = RetroHubGenericEmulator.find_and_substitute_str(curr_emulator["binpath"], {})
+	n_path.text = RetroHubGenericEmulator.find_path(curr_emulator, "binpath", {})
 	n_command.text = curr_emulator["command"]
 
 func save() -> Dictionary:
 	curr_emulator["fullname"] = n_fullname.text
 	curr_emulator["binpath"] = n_path.text
 	curr_emulator["command"] = n_command.text
+
+	RetroHubConfig.set_emulator_path(curr_emulator["name"], "binpath", n_path.text)
 
 	return curr_emulator
 

--- a/scenes/config/settings/emulator/RetroArchEmulatorEditor.gd
+++ b/scenes/config/settings/emulator/RetroArchEmulatorEditor.gd
@@ -35,11 +35,11 @@ func set_curr_emulator(_curr_emulator: Dictionary):
 	n_logo.text = "<click to add>" if not n_logo.icon else ""
 	n_name.text = curr_emulator["name"]
 	n_fullname.text = curr_emulator["fullname"]
-	n_path.text = RetroHubGenericEmulator.find_and_substitute_str(curr_emulator["binpath"], {})
+	n_path.text = RetroHubGenericEmulator.find_path(curr_emulator, "binpath", {})
 	n_core_path.text = RetroHubRetroArchEmulator.get_custom_core_path()
 	if n_core_path.text.is_empty():
-		n_core_path.text = RetroHubGenericEmulator.find_and_substitute_str(
-				curr_emulator["corepath"],
+		n_core_path.text = RetroHubGenericEmulator.find_path(
+				curr_emulator, "corepath",
 				{"binpath": n_path.text}
 		)
 	n_command.text = curr_emulator["command"]
@@ -68,6 +68,9 @@ func save() -> Dictionary:
 		n_core_option.set_item_text(n_core_option.selected, text)
 
 	curr_emulator["cores"] = cores.duplicate(true)
+
+	RetroHubConfig.set_emulator_path("retroarch", "binpath", n_path.text)
+	RetroHubConfig.set_emulator_path("retroarch", "corepath", n_core_path.text)
 
 	return curr_emulator
 


### PR DESCRIPTION
This change reduces unnecessary I/O by caching valid lookup paths for emulators to a new `_emulator_paths.json`, in order to try it the next time. The mechanism remains completely transparent to the user; if the cached path lookup fails, the existing mechanism then kicks in.

This also makes the existing emulator cache for the emulator first wizard screen redundant, so it was removed.

This change also fixes RetroArch's corepath always being overridden by what's specified in it's config file.

Closes #204.