### PR TITLE
Add volume slider configuration

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="RetroHub"
 run/main_scene="res://scenes/root/Root.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.2", "RetroHub")
 boot_splash/bg_color=Color(0.188235, 0.235294, 0.290196, 1)
 boot_splash/image="res://assets/icons/app/splash.png"
 config/icon="res://icon.png"

--- a/scenes/config/settings/GeneralSettings.gd
+++ b/scenes/config/settings/GeneralSettings.gd
@@ -7,6 +7,9 @@ extends Control
 @onready var n_language := %Language
 @onready var n_first_time_wizard_warning := %FirstTimeWizardWarning
 
+@onready var n_ui_volume_label := %UIVolumeLabel
+@onready var n_ui_volume := %UIVolume
+
 @onready var n_graphics_mode := %GraphicsMode
 @onready var n_vsync := %VSync
 @onready var n_render_res_label := %RenderResLabel
@@ -72,6 +75,7 @@ func _on_config_ready(config_data: ConfigData):
 	n_graphics_mode.selected = 1 if config_data.fullscreen else 0
 	n_vsync.set_pressed_no_signal(config_data.vsync)
 	n_render_res.value = config_data.render_resolution
+	n_ui_volume.value = config_data.ui_volume
 	set_language(config_data.lang)
 	n_screen_reader.set_pressed_no_signal(config_data.accessibility_screen_reader_enabled)
 
@@ -144,3 +148,9 @@ func _on_RenderRes_value_changed(value):
 func _on_ScreenReader_toggled(button_pressed):
 	RetroHubConfig.config.accessibility_screen_reader_enabled = button_pressed
 	RetroHubConfig._save_config()
+
+
+func _on_ui_volume_value_changed(value):
+	RetroHubConfig.config.ui_volume = value
+	n_ui_volume_label.text = str(value) + "%"
+	AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), linear_to_db(value / 100.0))

--- a/scenes/config/settings/GeneralSettings.tscn
+++ b/scenes/config/settings/GeneralSettings.tscn
@@ -125,6 +125,47 @@ layout_mode = 2
 size_flags_horizontal = 8
 text = "Re-run first time wizard"
 
+[node name="Sound" type="VBoxContainer" parent="ScrollContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/Sound"]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("2")
+text = "Sound"
+
+[node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/Sound/Label"]
+script = ExtResource("5")
+
+[node name="HSeparator" type="HSeparator" parent="ScrollContainer/VBoxContainer/Sound"]
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/Sound"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 15
+
+[node name="Label" type="Label" parent="ScrollContainer/VBoxContainer/Sound/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "UI volume:"
+
+[node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/Sound/HBoxContainer/Label"]
+script = ExtResource("5")
+
+[node name="UIVolumeLabel" type="Label" parent="ScrollContainer/VBoxContainer/Sound/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "100%"
+
+[node name="UIVolume" type="HSlider" parent="ScrollContainer/VBoxContainer/Sound/HBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+step = 5.0
+value = 1.0
+tick_count = 11
+ticks_on_borders = true
+
 [node name="Graphics" type="VBoxContainer" parent="ScrollContainer/VBoxContainer"]
 layout_mode = 2
 
@@ -279,6 +320,7 @@ vertical_alignment = 1
 [connection signal="pressed" from="ScrollContainer/VBoxContainer/User/HBoxContainer2/SetThemePath" to="." method="_on_SetThemePath_pressed"]
 [connection signal="item_selected" from="ScrollContainer/VBoxContainer/User/HBoxContainer3/Language" to="." method="_on_Language_item_selected"]
 [connection signal="pressed" from="ScrollContainer/VBoxContainer/User/SetupWizardButton" to="." method="_on_SetupWizardButton_pressed"]
+[connection signal="value_changed" from="ScrollContainer/VBoxContainer/Sound/HBoxContainer/UIVolume" to="." method="_on_ui_volume_value_changed"]
 [connection signal="item_selected" from="ScrollContainer/VBoxContainer/Graphics/HBoxContainer/GraphicsMode" to="." method="_on_GraphicsMode_item_selected"]
 [connection signal="toggled" from="ScrollContainer/VBoxContainer/Graphics/HBoxContainer2/VSync" to="." method="_on_VSync_toggled"]
 [connection signal="value_changed" from="ScrollContainer/VBoxContainer/Graphics/HBoxContainer3/RenderRes" to="." method="_on_RenderRes_value_changed"]

--- a/source/data/ConfigData.gd
+++ b/source/data/ConfigData.gd
@@ -36,6 +36,7 @@ var virtual_keyboard_show_on_controller : bool = true: set = _set_virtual_keyboa
 var virtual_keyboard_show_on_mouse : bool = false: set = _set_virtual_keyboard_show_on_mouse
 var accessibility_screen_reader_enabled : bool = true: set = _set_accessibility_screen_reader_enabled
 var custom_gamemedia_dir : String = "": set = _set_custom_gamemedia_dir
+var ui_volume : int = 100: set = _set_ui_volume
 
 const KEY_CONFIG_VERSION = "config_version"
 const KEY_IS_FIRST_TIME = "is_first_time"
@@ -66,6 +67,7 @@ const KEY_VIRTUAL_KEYBOARD_SHOW_ON_CONTROLLER = "virtual_keyboard_show_on_contro
 const KEY_VIRTUAL_KEYBOARD_SHOW_ON_MOUSE = "virtual_keyboard_show_on_mouse"
 const KEY_ACCESSIBILITY_SCREEN_READER_ENABLED = "accessibility_screen_reader_enabled"
 const KEY_CUSTOM_GAMEMEDIA_DIR = "custom_gamemedia_dir"
+const KEY_UI_VOLUME = "ui_volume"
 
 
 const _keys = [
@@ -97,7 +99,8 @@ const _keys = [
 	KEY_VIRTUAL_KEYBOARD_SHOW_ON_CONTROLLER,
 	KEY_VIRTUAL_KEYBOARD_SHOW_ON_MOUSE,
 	KEY_ACCESSIBILITY_SCREEN_READER_ENABLED,
-	KEY_CUSTOM_GAMEMEDIA_DIR
+	KEY_CUSTOM_GAMEMEDIA_DIR,
+	KEY_UI_VOLUME
 ]
 
 var _should_save : bool = true
@@ -302,6 +305,10 @@ func _set_accessibility_screen_reader_enabled(_accessibility_screen_reader_enabl
 func _set_custom_gamemedia_dir(_custom_gamemedia_dir):
 	mark_for_saving()
 	custom_gamemedia_dir = _custom_gamemedia_dir
+
+func _set_ui_volume(_ui_volume):
+	mark_for_saving()
+	ui_volume = _ui_volume
 
 func mark_for_saving():
 	if _should_save:


### PR DESCRIPTION
Adds an option to specify volume (for now acts on Master bus, figure out app/theme bus later). Closes #324.
![image](https://github.com/retrohub-org/retrohub/assets/6501975/d843219a-90fa-4983-9c2b-0335a82d2fe1)

Also took the opportunity to define a `RetroHub` engine feature to ensure users use the custom Godot build instead of vanilla one (https://github.com/retrohub-org/godot/commit/e89f8d134d91a99d1b5cf58f7b37f383e5d756a4).