### PR TITLE
Fix generic emulator names on first time wizard

### DIFF
--- a/scenes/popups/first_time/EmulatorsSection.gd
+++ b/scenes/popups/first_time/EmulatorsSection.gd
@@ -96,7 +96,7 @@ func handle_emulator_info(system_raw: Dictionary) -> bool:
 			var emulator : Dictionary = emulators[system_emulator]
 			parent.add_child(generic_info)
 
-			generic_info.set_name(emulator["fullname"])
+			generic_info.set_emu_name(emulator["fullname"])
 			if not icon_cache.has(system_emulator):
 				icon_cache[system_emulator] = RetroHubGenericEmulator.load_icon(system_emulator)
 			generic_info.set_logo(icon_cache[system_emulator])

--- a/scenes/popups/first_time/GenericEmulatorInfo.gd
+++ b/scenes/popups/first_time/GenericEmulatorInfo.gd
@@ -10,7 +10,7 @@ var found := false
 func _ready():
 	n_accessibility_focus._on_config_ready(RetroHubConfig.config)
 
-func set_name(_name: String):
+func set_emu_name(_name: String):
 	n_name.text = _name
 
 func set_logo(texture: Texture2D):


### PR DESCRIPTION
Existing function was clashing with Godot's internal one.