### PR TITLE
Fix scraper game picker selecting null entry when there's no games

### DIFF
--- a/scenes/config/ScraperSettings.tscn
+++ b/scenes/config/ScraperSettings.tscn
@@ -11,9 +11,6 @@
 
 [sub_resource type="FontFile" id="1"]
 fallbacks = Array[Font]([ExtResource("2")])
-face_index = null
-embolden = null
-transform = null
 cache/0/16/0/ascent = 0.0
 cache/0/16/0/descent = 0.0
 cache/0/16/0/underline_position = 0.0

--- a/scenes/popups/scraping_game_picker/ScrapingGamePickerPopup.gd
+++ b/scenes/popups/scraping_game_picker/ScrapingGamePickerPopup.gd
@@ -101,7 +101,9 @@ func get_selected_items(_root: TreeItem):
 			if _root.get_children():
 				selected_items.append_array(get_selected_items(next.get_child(0)))
 			elif next.is_checked(1):
-				selected_items.append(next.get_metadata(0))
+				var game : RetroHubGameData = next.get_metadata(0)
+				if game:
+					selected_items.append(game)
 			next = next.get_next()
 	return selected_items
 


### PR DESCRIPTION
Ensures there's valid metadata before reporting it.