### PR TITLE
Tweaks due to engine update to v4.2.1-stable

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -111,7 +111,7 @@ jobs:
         uses: ./godot/.github/actions/godot-build
         with:
           root: ./godot
-          sconsflags: verbose=yes warnings=all werror=yes use_lto=yes optimize=size arch=${{ matrix.arch }}
+          sconsflags: verbose=yes warnings=all werror=no use_lto=yes optimize=size arch=${{ matrix.arch }}
           platform: linuxbsd
           target: template_release
           tools: false

--- a/.github/workflows/mac_build.yml
+++ b/.github/workflows/mac_build.yml
@@ -145,7 +145,7 @@ jobs:
         uses: ./godot/.github/actions/godot-build
         with:
           root: ./godot
-          sconsflags: verbose=yes warnings=all werror=yes use_lto=yes optimize=size arch=x86_64
+          sconsflags: verbose=yes warnings=all werror=no use_lto=yes optimize=size arch=x86_64
           platform: macos
           target: template_release
           tools: false
@@ -155,7 +155,7 @@ jobs:
         uses: ./godot/.github/actions/godot-build
         with:
           root: ./godot
-          sconsflags: verbose=yes warnings=all werror=yes use_lto=yes optimize=size arch=arm64
+          sconsflags: verbose=yes warnings=all werror=no use_lto=yes optimize=size arch=arm64
           platform: macos
           target: template_release
           tools: false

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -115,7 +115,7 @@ jobs:
         uses: ./godot/.github/actions/godot-build
         with:
           root: ./godot
-          sconsflags: verbose=yes warnings=all werror=yes use_lto=yes optimize=size arch=${{ matrix.arch }}
+          sconsflags: verbose=yes warnings=all werror=no use_lto=yes optimize=size arch=${{ matrix.arch }}
           platform: windows
           target: template_release
           tools: false

--- a/resources/default_theme.tres
+++ b/resources/default_theme.tres
@@ -202,16 +202,6 @@ corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_cejk0"]
-content_margin_left = 10.0
-content_margin_top = 4.0
-content_margin_right = 10.0
-content_margin_bottom = 4.0
-bg_color = Color(0.207843, 0.258824, 0.392157, 1)
-border_width_top = 2
-border_color = Color(1, 0.733333, 0.537255, 1)
-corner_detail = 1
-
 [sub_resource type="StyleBoxEmpty" id="1594"]
 content_margin_left = 4.0
 content_margin_top = 4.0
@@ -502,6 +492,16 @@ border_width_right = 1
 border_color = Color(0.175, 0.175, 0.175, 1)
 corner_detail = 1
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_cejk0"]
+content_margin_left = 10.0
+content_margin_top = 4.0
+content_margin_right = 10.0
+content_margin_bottom = 4.0
+bg_color = Color(0.207843, 0.258824, 0.392157, 1)
+border_width_top = 2
+border_color = Color(1, 0.733333, 0.537255, 1)
+corner_detail = 1
+
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_a00um"]
 content_margin_left = 10.0
 content_margin_top = 6.0
@@ -701,7 +701,6 @@ HSlider/styles/grabber_area = SubResource("StyleBoxFlat_3eyyw")
 HSlider/styles/grabber_area_highlight = SubResource("StyleBoxFlat_rpnq8")
 HSlider/styles/slider = SubResource("StyleBoxFlat_go4h4")
 HyperFocused/styles/focus = SubResource("4878")
-HyperFocused/styles/tab_selected = SubResource("StyleBoxFlat_cejk0")
 Label/constants/line_spacing = 3
 Label/styles/normal = SubResource("1594")
 LineEdit/colors/clear_button_color_pressed = Color(1, 0.733333, 0.537255, 1)
@@ -711,19 +710,23 @@ LineEdit/styles/focus = SubResource("4827")
 LineEdit/styles/normal = SubResource("4")
 LineEdit/styles/read_only = SubResource("4783")
 LinkButton/colors/font_pressed_color = Color(1, 0.733333, 0.537255, 1)
+MenuSideBottomButton/base_type = &"Button"
 MenuSideBottomButton/colors/font_color_pressed = Color(1, 1, 1, 1)
 MenuSideBottomButton/colors/icon_color_pressed = Color(1, 0.733333, 0.537255, 1)
 MenuSideBottomButton/styles/focus = SubResource("4649")
 MenuSideBottomButton/styles/hover = SubResource("4649")
 MenuSideBottomButton/styles/normal = SubResource("4739")
 MenuSideBottomButton/styles/pressed = SubResource("4648")
+MenuSideButton/base_type = &"Button"
 MenuSideButton/colors/font_color_pressed = Color(1, 1, 1, 1)
 MenuSideButton/colors/icon_color_pressed = Color(1, 0.733333, 0.537255, 1)
 MenuSideButton/styles/focus = SubResource("4516")
 MenuSideButton/styles/hover = SubResource("4339")
 MenuSideButton/styles/normal = SubResource("4383")
 MenuSideButton/styles/pressed = SubResource("4295")
+MenuSidePanel/base_type = &"Panel"
 MenuSidePanel/styles/panel = SubResource("4427")
+MenuSideTopButton/base_type = &"Button"
 MenuSideTopButton/colors/font_color_pressed = Color(1, 1, 1, 1)
 MenuSideTopButton/colors/icon_color_pressed = Color(1, 0.733333, 0.537255, 1)
 MenuSideTopButton/styles/focus = SubResource("4694")
@@ -762,6 +765,7 @@ ScrollContainer/styles/panel = SubResource("StyleBoxEmpty_5h327")
 TabContainer/constants/side_margin = 30
 TabContainer/styles/panel = SubResource("1639")
 TabContainer/styles/tab_disabled = SubResource("StyleBoxFlat_hj66r")
+TabContainer/styles/tab_focus = SubResource("StyleBoxFlat_cejk0")
 TabContainer/styles/tab_hovered = SubResource("StyleBoxFlat_cejk0")
 TabContainer/styles/tab_selected = SubResource("StyleBoxFlat_a00um")
 TabContainer/styles/tab_unselected = SubResource("StyleBoxFlat_pmenl")
@@ -793,4 +797,5 @@ VSlider/styles/slider = SubResource("StyleBoxFlat_go4h4")
 Window/styles/embedded_border = SubResource("StyleBoxFlat_sfm0d")
 Window/styles/embedded_unfocused_border = SubResource("StyleBoxFlat_sfm0d")
 Window/styles/panel = SubResource("1662")
+WindowPanel/base_type = &"Window"
 WindowPanel/styles/panel = SubResource("StyleBoxFlat_e1x58")

--- a/scenes/config/AboutSettings.tscn
+++ b/scenes/config/AboutSettings.tscn
@@ -104,12 +104,12 @@ size_flags_horizontal = 8
 [node name="OpenWebsiteButton" type="Button" parent="TabContainerHandler/TabContainer/About/VBoxContainer/HBoxContainer/HFlowContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-focus_neighbor_top = NodePath("../../../../../..")
+focus_neighbor_top = NodePath("../../../../..")
 text = "Open project website"
 
 [node name="OpenIssuesButton" type="Button" parent="TabContainerHandler/TabContainer/About/VBoxContainer/HBoxContainer/HFlowContainer"]
 layout_mode = 2
-focus_neighbor_bottom = NodePath("../../../../../..")
+focus_neighbor_bottom = NodePath("../../../../..")
 text = "Report issues"
 
 [node name="HSeparator" type="HSeparator" parent="TabContainerHandler/TabContainer/About/VBoxContainer"]
@@ -698,8 +698,8 @@ anchor_bottom = 1.0
 unique_name_in_owner = true
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
-focus_neighbor_top = NodePath("../../../..")
-focus_neighbor_bottom = NodePath("../../../..")
+focus_neighbor_top = NodePath("../../..")
+focus_neighbor_bottom = NodePath("../../..")
 hide_root = true
 
 [node name="AccessibilityFocus" type="Node" parent="TabContainerHandler/TabContainer/Licenses/HBoxContainer/Names"]

--- a/scenes/config/settings/InputSettings.tscn
+++ b/scenes/config/settings/InputSettings.tscn
@@ -83,7 +83,6 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Keyboard" type="VBoxContainer" parent="ScrollContainer/VBoxContainer/TabContainerHandler/InputTab"]
-visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -92,7 +91,6 @@ size_flags_vertical = 3
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
-focus_neighbor_top = NodePath("../../..")
 focus_neighbor_bottom = NodePath("../HBoxContainer/VBoxContainer/HBoxContainer/KBAccept")
 text = "Reset to default mapping"
 
@@ -120,6 +118,7 @@ custom_minimum_size = Vector2(60, 60)
 layout_mode = 2
 tooltip_text = "Accept"
 focus_neighbor_left = NodePath("../../../../KBReset")
+focus_neighbor_top = NodePath("../../../../KBReset")
 focus_neighbor_right = NodePath("../../../VBoxContainer2/HBoxContainer/KBMoveUp")
 icon = ExtResource("2")
 expand_icon = true
@@ -224,7 +223,7 @@ custom_minimum_size = Vector2(60, 60)
 layout_mode = 2
 tooltip_text = "Theme menu"
 focus_neighbor_right = NodePath("../../../VBoxContainer2/HBoxContainer6/KBSlideRight")
-focus_neighbor_bottom = NodePath("../../../../../..")
+focus_neighbor_bottom = NodePath("../../../../..")
 icon = ExtResource("8")
 expand_icon = true
 script = ExtResource("26")
@@ -249,6 +248,7 @@ text = "Move up"
 custom_minimum_size = Vector2(60, 60)
 layout_mode = 2
 tooltip_text = "Move up"
+focus_neighbor_top = NodePath("../../../../KBReset")
 icon = ExtResource("11")
 expand_icon = true
 script = ExtResource("26")
@@ -351,7 +351,7 @@ custom_minimum_size = Vector2(60, 60)
 layout_mode = 2
 tooltip_text = "Slide right"
 focus_neighbor_left = NodePath("../../../VBoxContainer/HBoxContainer6/KBThemeMenu")
-focus_neighbor_bottom = NodePath("../../../../../..")
+focus_neighbor_bottom = NodePath("../../../../..")
 icon = ExtResource("14")
 expand_icon = true
 script = ExtResource("26")
@@ -384,7 +384,6 @@ layout_mode = 2
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
-focus_neighbor_top = NodePath("../../../../..")
 text = "Reset to default mapping"
 
 [node name="VSeparator" type="VSeparator" parent="ScrollContainer/VBoxContainer/TabContainerHandler/InputTab/Controller/VBoxContainer/HBoxContainer4"]
@@ -394,14 +393,12 @@ layout_mode = 2
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
-focus_neighbor_top = NodePath("../../../../..")
 text = "Create controller layout"
 
 [node name="CNClearLayout" type="Button" parent="ScrollContainer/VBoxContainer/TabContainerHandler/InputTab/Controller/VBoxContainer/HBoxContainer4"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
-focus_neighbor_top = NodePath("../../../../..")
 text = "Clear custom layout"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/VBoxContainer/TabContainerHandler/InputTab/Controller/VBoxContainer"]
@@ -628,7 +625,7 @@ custom_minimum_size = Vector2(60, 60)
 layout_mode = 2
 tooltip_text = "RetroHub menu"
 focus_neighbor_right = NodePath("../../../VBoxContainer2/HBoxContainer4/CNSlideRight")
-focus_neighbor_bottom = NodePath("../../../../../..")
+focus_neighbor_bottom = NodePath("../../../../..")
 icon = ExtResource("33_jbqxx")
 expand_icon = true
 script = ExtResource("26")
@@ -736,7 +733,7 @@ custom_minimum_size = Vector2(60, 60)
 layout_mode = 2
 tooltip_text = "Slide right"
 focus_neighbor_left = NodePath("../../../VBoxContainer/HBoxContainer5/CNRetroHubMenu")
-focus_neighbor_bottom = NodePath("../../../../../..")
+focus_neighbor_bottom = NodePath("../../../../..")
 icon = ExtResource("25")
 expand_icon = true
 script = ExtResource("26")
@@ -748,6 +745,7 @@ script = ExtResource("44")
 next = NodePath("../../../../../../..")
 
 [node name="Virtual Keyboard" type="VBoxContainer" parent="ScrollContainer/VBoxContainer/TabContainerHandler/InputTab"]
+visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -768,7 +766,6 @@ script = ExtResource("44")
 unique_name_in_owner = true
 custom_minimum_size = Vector2(180, 0)
 layout_mode = 2
-focus_neighbor_top = NodePath("../../../..")
 item_count = 3
 selected = 0
 popup/item_0/text = "QWERTY"
@@ -823,7 +820,7 @@ text = "On Controller Input"
 [node name="VirtualKeyboardOnMouse" type="CheckBox" parent="ScrollContainer/VBoxContainer/TabContainerHandler/InputTab/Virtual Keyboard/HBoxContainer2/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-focus_neighbor_bottom = NodePath("../../../../..")
+focus_neighbor_bottom = NodePath("../../../..")
 text = "On Mouse Click/Touch"
 
 [node name="AccessibilityFocus" type="Node" parent="ScrollContainer/VBoxContainer/TabContainerHandler/InputTab/Virtual Keyboard/HBoxContainer2/VBoxContainer/VirtualKeyboardOnMouse"]

--- a/source/utils/TabContainerHandler.gd
+++ b/source/utils/TabContainerHandler.gd
@@ -15,22 +15,19 @@ var _focused := false
 func _ready():
 	# This _ready is called before parent, we need to wait a frame for parent to initialize
 	await get_tree().process_frame
-	focus_mode = Control.FOCUS_ALL
-	focus_entered.connect(_on_focus_entered)
-	focus_exited.connect(_on_focus_exited)
 	tab = get_child(0) if get_child_count() > 0 else null
 	if not tab or not tab is TabContainer:
 		push_error("TabContainerHandler has no TabContainer child! Queueing free...")
 		queue_free()
 	tab.tab_clicked.connect(_on_tab_clicked)
+	tab.get_tab_bar().focus_entered.connect(_on_focus_entered)
+	tab.get_tab_bar().focus_exited.connect(_on_focus_exited)
 
 func _on_focus_entered():
 	_focused = true
-	tab.theme_type_variation = "HyperFocused"
 
 func _on_focus_exited():
 	_focused = false
-	tab.theme_type_variation = ""
 
 func _input(event):
 	if is_visible_in_tree():
@@ -71,7 +68,8 @@ func _on_tab_clicked(_tab_idx: int):
 	handle_focus(not _focused)
 
 func handle_focus(enter_tab: bool):
-	RetroHubUI.play_sound(RetroHubUI.AudioKeys.SLIDE)
+	if not enter_tab:
+		RetroHubUI.play_sound(RetroHubUI.AudioKeys.SLIDE)
 	await get_tree().process_frame
 	if signal_tab_change:
 		emit_signal("tab_changed", tab, enter_tab)

--- a/source/utils/UIAudio.gd
+++ b/source/utils/UIAudio.gd
@@ -89,9 +89,7 @@ func connect_signals(node: Node):
 		node.visibility_changed.connect(_window_visibility_changed.bind(node))
 	elif node is Range:
 		node.value_changed.connect(range_value_changed.bind(node))
-	elif node is TabContainerHandler:
-		node.tab_changed.connect(tab_container_handler_changed.bind(node))
-	elif node is TabContainer:
+	elif node is TabBar:
 		node.tab_changed.connect(tab_container_tab_changed.bind(node))
 	elif node is Tree:
 		node.item_selected.connect(_tree_item_or_cell_selected.bind(node))


### PR DESCRIPTION
The engine was updated to the newest v4.2.1 stable version. A few tweaks were needed to update the project.

Most notably, Tabs are now finally focusable, so our workaround is not needed anymore. While code was simplified there, it can't be removed entirely due to other behaviors.