### PR TITLE
Implement internal Godot settings

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -12,6 +12,7 @@ config_version=5
 
 config/name="RetroHub"
 run/main_scene="res://scenes/root/Root.tscn"
+config/project_settings_override="user://engine_settings.cfg"
 config/features=PackedStringArray("4.2", "RetroHub")
 boot_splash/bg_color=Color(0.188235, 0.235294, 0.290196, 1)
 boot_splash/image="res://assets/icons/app/splash.png"
@@ -200,7 +201,6 @@ rh_rstick_down={
 [memory]
 
 limits/message_queue/max_size_mb=128
-limits/command_queue/multithreading_queue_size_kb=1024
 
 [physics]
 
@@ -210,4 +210,3 @@ common/enable_pause_aware_picking=true
 
 environment/defaults/default_clear_color=Color(0.188235, 0.235294, 0.290196, 1)
 environment/defaults/default_environment="res://default_env.tres"
-threads/thread_model=2

--- a/scenes/config/settings/GeneralSettings.gd
+++ b/scenes/config/settings/GeneralSettings.gd
@@ -75,7 +75,8 @@ func _on_config_ready(config_data: ConfigData):
 	n_graphics_mode.selected = 1 if config_data.fullscreen else 0
 	n_vsync.set_pressed_no_signal(config_data.vsync)
 	n_render_res.value = config_data.render_resolution
-	n_ui_volume.value = config_data.ui_volume
+	n_ui_volume.set_value_no_signal(config_data.ui_volume)
+	AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), linear_to_db(config_data.ui_volume / 100.0))
 	set_language(config_data.lang)
 	n_screen_reader.set_pressed_no_signal(config_data.accessibility_screen_reader_enabled)
 

--- a/scenes/root/Root.gd
+++ b/scenes/root/Root.gd
@@ -48,8 +48,6 @@ func _ready():
 	await get_tree().process_frame
 	if RetroHubConfig.config.is_first_time:
 		show_first_time_popup()
-	get_window().mode = Window.MODE_EXCLUSIVE_FULLSCREEN if (RetroHubConfig.config.fullscreen) else Window.MODE_WINDOWED
-	DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_ENABLED if (RetroHubConfig.config.vsync) else DisplayServer.VSYNC_DISABLED)
 	setup_controller_remap(RetroHubConfig.config.custom_input_remap)
 
 func _notification(what):


### PR DESCRIPTION
Closes #339

Godot can override engine settings through a settings file, which can be in a user-writable directory like `user://`. This is needed to properly override some core settings before launching, most notable fullscreen.

RetroHub now replicates such settings and writes them to an internal file (`user://engine_settings.cfg`). Currently this applies only to window mode and V-Sync. In the future, this will also allow, for instance, to change the graphics backend (Vulkan or OpenGL)

Additionally this fixes the new UI volume setting causing a needless save operation every time.