### PR TITLE
Fix improper check to verify RetroAchievements request was valid

### DIFF
--- a/source/integrations/RetroAchievementsIntegration.gd
+++ b/source/integrations/RetroAchievementsIntegration.gd
@@ -468,8 +468,7 @@ func _ready() -> void:
 		queue_free()
 		return
 
-	if Raw.http:
-		remove_child(Raw.http)
+	if is_instance_valid(Raw.http):
 		Raw.http.queue_free()
 	Raw.http = HTTPRequest.new()
 	Raw.http.accept_gzip = true


### PR DESCRIPTION
Since we don't set it to `null` directly, we tried to free a previously freed instance. This fixes the check.