### PR TITLE
Fix macOS code signing for external dependencies, and support arm64 versions of FFMPEG

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: "Checkout RetroHub"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: "retrohub"
 
       - name: "Load cached objects (Godot editor)"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: "cache_editor"
         with:
           path: cached_builds/editor/godot
@@ -38,7 +38,7 @@ jobs:
         continue-on-error: true
 
       - name: "Load cached objects (Godot templates)"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: "cache_template"
         with:
           path: cached_builds/template/${{ matrix.template }}
@@ -46,7 +46,7 @@ jobs:
         continue-on-error: true
 
       - name: "Load cached objects (Videodecoder)"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: "cache_videodecoder"
         with:
           path: cached_builds/videodecoder/${{ matrix.videodecoder }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: "Checkout Custom Godot"
         if: steps.cache_template.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: retrohub-org/godot
           ref: retrohub_patches_4x
@@ -63,7 +63,7 @@ jobs:
 
       - name: "Checkout godot-videodecoder"
         if: steps.cache_videodecoder.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: retrohub-org/godot-videodecoder
           submodules: recursive
@@ -154,7 +154,7 @@ jobs:
           chmod +x ../export/linux_${{ matrix.arch }}/RetroHub
 
       - name: "Upload Artifacts"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-${{ matrix.arch }}
           path: export/linux_${{ matrix.arch }}

--- a/.github/workflows/mac_build.yml
+++ b/.github/workflows/mac_build.yml
@@ -11,11 +11,12 @@ jobs:
     name: Extract SDK
     steps:
       - name: "Load cache"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: "cache"
         with:
           path: ~/cached_builds/sdk
           key: MacOS-sdk
+          save-always: true
         continue-on-error: true
 
       - name: "Checkout osxcross"
@@ -27,10 +28,6 @@ jobs:
       - name: "Extract SDK"
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          #ls /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs
-          #sed 's/\^MacOSX13\.\*|//g' tools/gen_sdk_package.sh > tools/gen_sdk_package.sh.patched
-          #mv tools/gen_sdk_package.sh.patched tools/gen_sdk_package.sh
-          #chmod +x tools/gen_sdk_package.sh
           XCODEDIR=/Applications/Xcode_14.0.1.app ./tools/gen_sdk_package.sh
           mkdir -p -v ~/cached_builds/sdk
           mv MacOSX12.3.sdk.tar.xz ~/cached_builds/sdk
@@ -42,7 +39,7 @@ jobs:
 
     steps:
       - name: "Load cache (SDK)"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: "cache-sdk"
         with:
           path: ~/cached_builds/sdk
@@ -50,16 +47,19 @@ jobs:
         continue-on-error: false
 
       - name: "Load cache (videodecoder)"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: "cache-videodecoder"
         with:
-          path: cached_builds/videodecoder/macos
+          path: |
+            cached_builds/videodecoder/macos_x86
+            cached_builds/videodecoder/macos_arm64
           key: MacOS-videodecoder-build
+          save-always: true
         continue-on-error: true
 
       - name: "Checkout godot-videodecoder"
         if: steps.cache-videodecoder.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: retrohub-org/godot-videodecoder
           submodules: recursive
@@ -67,7 +67,7 @@ jobs:
       - name: "Compile"
         if: steps.cache-videodecoder.outputs.cache-hit != 'true'
         env:
-          PLATFORMS: macos
+          PLATFORMS: macos_x86,macos_arm64
         run: |
           mv ~/cached_builds/sdk/MacOSX12.3.sdk.tar.xz darwin_sdk
           ./build_gdextension.sh
@@ -81,12 +81,12 @@ jobs:
 
     steps:
       - name: "Checkout RetroHub"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: "retrohub"
 
       - name: "Load cached objects (Godot editor)"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: "cache_editor"
         with:
           path: cached_builds/editor/Godot.app
@@ -94,7 +94,7 @@ jobs:
         continue-on-error: true
 
       - name: "Load cached objects (Godot templates)"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: "cache_template"
         with:
           path: cached_builds/template/macos.zip
@@ -102,16 +102,18 @@ jobs:
         continue-on-error: true
 
       - name: "Load cached objects (Videodecoder)"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: "cache_videodecoder"
         with:
-          path: cached_builds/videodecoder/macos
+          path: |
+            cached_builds/videodecoder/macos_x86
+            cached_builds/videodecoder/macos_arm64
           key: MacOS-videodecoder-build
         continue-on-error: false
 
       - name: "Checkout Custom Godot"
         if: steps.cache_template.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: retrohub-org/godot
           ref: retrohub_patches_4x
@@ -180,6 +182,20 @@ jobs:
           unzip Godot_v4.1-stable_macos.universal.zip
           mkdir -p -v cached_builds/editor
           mv Godot.app cached_builds/editor/
+      
+      - name: "[videodecoder] Bundle x86_64 and arm64 libraries"
+        run: |
+          mkdir -p -v cached_builds/videodecoder/macos
+          ls -la cached_builds/videodecoder/
+          echo "---"
+          ls -la cached_builds/videodecoder/macos_x86
+          echo "---"
+          ls -la cached_builds/videodecoder/macos_arm64
+          echo "---"
+          for f in cached_builds/videodecoder/macos_x86/*.dylib; do
+            lipo -create $f cached_builds/videodecoder/macos_arm64/$(basename $f) -output cached_builds/videodecoder/macos/$(basename $f)
+          done
+          file cached_builds/videodecoder/macos/*.dylib
 
       - name: "Setup templates and libraries"
         env:
@@ -196,7 +212,7 @@ jobs:
       - name: "Exporting RetroHub"
         working-directory: retrohub
         run: |
-          ../cached_builds/editor/Godot.app/Contents/MacOS/Godot --headless --export-release "macOS" ../export/macos/RetroHub.app
+          ../cached_builds/editor/Godot.app/Contents/MacOS/Godot --headless --verbose --export-release "macOS" ../export/macos/RetroHub.app
         
       - name: "Sign executable"
         working-directory: export/macos
@@ -205,7 +221,7 @@ jobs:
           codesign -s - --force --deep "RetroHub.app"
 
       - name: "Upload Artifacts"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos
           path: export/macos

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: "Checkout RetroHub"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: "retrohub"
 
       - name: "Load cached objects (Godot editor)"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: "cache_editor"
         with:
           path: cached_builds/editor/godot
@@ -38,7 +38,7 @@ jobs:
         continue-on-error: true
 
       - name: "Load cached objects (Godot templates)"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: "cache_template"
         with:
           path: cached_builds/template/${{ matrix.template }}
@@ -46,7 +46,7 @@ jobs:
         continue-on-error: true
 
       - name: "Load cached objects (Videodecoder)"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: "cache_videodecoder"
         with:
           path: cached_builds/videodecoder/${{ matrix.videodecoder }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: "Checkout Custom Godot"
         if: steps.cache_template.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: retrohub-org/godot
           ref: retrohub_patches_4x
@@ -63,7 +63,7 @@ jobs:
 
       - name: "Checkout godot-videodecoder"
         if: steps.cache_videodecoder.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: retrohub-org/godot-videodecoder
           submodules: recursive
@@ -164,7 +164,7 @@ jobs:
           ../cached_builds/editor/godot --headless --export-release "Windows (${{ matrix.arch }})" ../export/windows_${{ matrix.arch }}/RetroHub.exe
 
       - name: "Upload Artifacts"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-${{ matrix.arch }}
           path: export/windows_${{ matrix.arch }}

--- a/addons/godot-blurhash/macos/libblurhash.template_debug.framework/Info.plist
+++ b/addons/godot-blurhash/macos/libblurhash.template_debug.framework/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>libblurhash.template_debug</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.github.rsubtil.godot-blurhash</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libblurhash.macos.template_debug</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1.0.0</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.12</string>
+</dict>
+</plist>

--- a/addons/godot-blurhash/macos/libblurhash.template_release.framework/Info.plist
+++ b/addons/godot-blurhash/macos/libblurhash.template_release.framework/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>libblurhash.template_release</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.github.rsubtil.godot-blurhash</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libblurhash.macos.template_release</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1.0.0</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.12</string>
+</dict>
+</plist>

--- a/addons/godot-rcheevos-rhash/macos/librcheevos-rhash.template_debug.framework/Info.plist
+++ b/addons/godot-rcheevos-rhash/macos/librcheevos-rhash.template_debug.framework/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>librcheevos-rhash.template_debug</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.retrohub.godot-rcheevos-rhash</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>librcheevos-rhash.macos.template_debug</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1.0.0</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.12</string>
+</dict>
+</plist>

--- a/addons/godot-rcheevos-rhash/macos/librcheevos-rhash.template_release.framework/Info.plist
+++ b/addons/godot-rcheevos-rhash/macos/librcheevos-rhash.template_release.framework/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>librcheevos-rhash.template_release</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.retrohub.godot-rcheevos-rhash</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>librcheevos-rhash.macos.template_release</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1.0.0</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.12</string>
+</dict>
+</plist>

--- a/addons/godot-videodecoder/godot-videodecoder.gdextension
+++ b/addons/godot-videodecoder/godot-videodecoder.gdextension
@@ -3,8 +3,8 @@ entry_symbol = "init"
 compatibility_minimum = 4.1
 
 [libraries]
-macos.release.universal = "macos/libgdvideo-template_release.dylib"
-macos.debug.universal = "macos/libgdvideo-template_debug.dylib"
+macos.release = "macos/libgdvideo-template_release.dylib"
+macos.debug = "macos/libgdvideo-template_debug.dylib"
 windows.release.x86_64 = "windows_64/libgdvideo-template_release.dll"
 windows.debug.x86_64 = "windows_64/libgdvideo-template_debug.dll"
 windows.release.x86_32 = "windows_32/libgdvideo-template_release.dll"
@@ -15,7 +15,7 @@ linux.release.x86_32 = "linux_32/libgdvideo-template_release.so"
 linux.debug.x86_32 = "linux_32/libgdvideo-template_debug.so"
 
 [dependencies]
-macos.universal = {"macos/libavcodec.58.dylib": "", "macos/libavdevice.58.dylib": "", "macos/libavfilter.7.dylib": "", "macos/libavformat.58.dylib": "", "macos/libavutil.56.dylib": "", "macos/libpostproc.55.dylib": "", "macos/libswresample.3.dylib": "", "macos/libswscale.5.dylib": ""}
+macos = {"macos/libavcodec.58.dylib": "", "macos/libavdevice.58.dylib": "", "macos/libavfilter.7.dylib": "", "macos/libavformat.58.dylib": "", "macos/libavutil.56.dylib": "", "macos/libpostproc.55.dylib": "", "macos/libswresample.3.dylib": "", "macos/libswscale.5.dylib": ""}
 windows.x86_64 = {"windows_64/avcodec-58.dll": "", "windows_64/avdevice-58.dll": "", "windows_64/avfilter-7.dll": "", "windows_64/avformat-58.dll": "", "windows_64/avutil-56.dll": "", "windows_64/libwinpthread-1.dll": "", "windows_64/postproc-55.dll": "", "windows_64/swresample-3.dll": "", "windows_64/swscale-5.dll": ""}
 windows.x86_32 = {"windows_32/avcodec-58.dll": "", "windows_32/avdevice-58.dll": "", "windows_32/avfilter-7.dll": "", "windows_32/avformat-58.dll": "", "windows_32/avutil-56.dll": "", "windows_32/libwinpthread-1.dll": "", "windows_32/postproc-55.dll": "", "windows_32/swresample-3.dll": "", "windows_32/swscale-5.dll": ""}
 linux.x86_64 = {"linux_64/libavcodec.so.58": "", "linux_64/libavdevice.so.58": "", "linux_64/libavfilter.so.7": "", "linux_64/libavformat.so.58": "", "linux_64/libavutil.so.56": "", "linux_64/libpostproc.so.55": "", "linux_64/libswresample.so.3": "", "linux_64/libswscale.so.5": ""}


### PR DESCRIPTION
Fixes #358

A generic `macos.release/debug` key is now used, and the FFMPEG/godot-videodecoder dependency is now bundled as a universal dependency. It should also now "in theory" fully support M1 systems, but this needs to be tested and reported by someone else to be working properly.

Since we're already touching CI files, other pending changes were done as well:
- Upgrade actions to v4 according to deprecation notices
- Added `save-always` flag on macOS caches, which should massively speed-up the process when CI fails