### PR TITLE
Increase ScreenScraper timeout to 30 seconds

### DIFF
--- a/source/scraper/ScreenScraperScraper.gd
+++ b/source/scraper/ScreenScraperScraper.gd
@@ -21,7 +21,7 @@ class RequestDetails:
 		#warning-ignore:return_value_discarded
 		_http.request_completed.connect(_on_request_completed)
 		_http.use_threads = true
-		_http.timeout = 10
+		_http.timeout = 30
 
 	func _on_request_completed(result: int, response_code: int, headers: PackedStringArray, body: PackedByteArray):
 		_req_result = result


### PR DESCRIPTION
ScreenScraper has become quite unreliable these last few months. It's affecting all frontends, and notably ES-DE also increased the timeout limit to work around this.

This increases the timeout limit to 30 seconds.