### PR TITLE
Fix emulator launching not working

### DIFF
--- a/scenes/config/settings/EmulatorLaunchedPopup.gd
+++ b/scenes/config/settings/EmulatorLaunchedPopup.gd
@@ -4,7 +4,7 @@ var pid := 0
 
 func _process(delta):
 	if not visible: return
-	if pid >= 0 or not OS.is_process_running(pid):
+	if pid > 0 and not OS.is_process_running(pid):
 		# Request focus, as we might not have it
 		get_tree().root.move_to_foreground()
 		_on_close_requested()

--- a/scenes/config/settings/emulator/EmulatorEditor.gd
+++ b/scenes/config/settings/emulator/EmulatorEditor.gd
@@ -72,5 +72,6 @@ func _on_LoadPath_pressed():
 
 func _on_run_emulator_pressed():
 	var path : String = n_path.text
+	if path.is_empty(): return
 	var pid := OS.create_process(path, [])
 	emulator_launched.emit(pid)

--- a/scenes/config/settings/emulator/RetroArchEmulatorEditor.gd
+++ b/scenes/config/settings/emulator/RetroArchEmulatorEditor.gd
@@ -169,5 +169,6 @@ func _on_AddCore_pressed():
 
 func _on_run_emulator_pressed():
 	var path : String = n_path.text
+	if path.is_empty(): return
 	var pid := OS.create_process(path, [])
 	emulator_launched.emit(pid)


### PR DESCRIPTION
Due to the written logic, the emulator was being killed instantly.

This also prevents launching a process if the path is empty, to avoid an unnecessary 1-frame popup.