### PR TITLE
Restore shader parameters

### DIFF
--- a/resources/shaders/MenuBlur.gdshader
+++ b/resources/shaders/MenuBlur.gdshader
@@ -6,9 +6,9 @@ shader_type canvas_item;
 // are not being used on exported projects from the editor
 // So far this hasn't been replicated on vanilla Godot, but it's likely
 // an engine bug. Investigate later
-uniform float blur_amount : hint_range(0, 5) = 1;
+uniform float blur_amount : hint_range(0, 5);
 uniform sampler2D SCREEN_TEXTURE : hint_screen_texture, filter_linear_mipmap;
-uniform vec4 modulate : source_color = vec4(0.749, 0.749, 0.749, 1.0);
+uniform vec4 modulate : source_color;
 
 void fragment() {
 	COLOR = textureLod(SCREEN_TEXTURE, SCREEN_UV, blur_amount) * modulate;


### PR DESCRIPTION
Take two of #299, as it may be fixed now that we compile a custom editor build to export the project.