### PR TITLE
Fix first time popup losing focus when selecting paths

### DIFF
--- a/scenes/popups/first_time/GamesSection.gd
+++ b/scenes/popups/first_time/GamesSection.gd
@@ -34,6 +34,7 @@ func _on_NextButton_pressed():
 func _on_ChooseDir_pressed():
 	RetroHubUI.request_folder_load(n_path.text)
 	set_path(await RetroHubUI.path_selected)
+	get_window().grab_focus()
 
 func set_path(path: String):
 	if not path.is_empty():
@@ -60,6 +61,7 @@ func query_next_btn():
 func _on_media_choose_dir_pressed():
 	RetroHubUI.request_folder_load(n_media_path.text)
 	set_media_path(await RetroHubUI.path_selected)
+	get_window().grab_focus()
 
 func set_media_path(path: String):
 	if not path.is_empty():

--- a/scenes/popups/first_time/GamesSection.tscn
+++ b/scenes/popups/first_time/GamesSection.tscn
@@ -58,6 +58,9 @@ layout_mode = 2
 size_flags_horizontal = 3
 text = "Store downloaded media in the configuration directory?"
 
+[node name="AccessibilityFocus" type="Node" parent="VBoxContainer/HBoxContainer2/Label"]
+script = ExtResource("3")
+
 [node name="UseCustomMedia" type="CheckButton" parent="VBoxContainer/HBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
@@ -76,6 +79,9 @@ layout_mode = 2
 [node name="Label" type="Label" parent="VBoxContainer/CustomMediaContainer/VBoxContainer"]
 layout_mode = 2
 text = "Game media location"
+
+[node name="AccessibilityFocus" type="Node" parent="VBoxContainer/CustomMediaContainer/VBoxContainer/Label"]
+script = ExtResource("3")
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/CustomMediaContainer/VBoxContainer"]
 layout_mode = 2

--- a/source/UI.gd
+++ b/source/UI.gd
@@ -100,7 +100,7 @@ func _on_popup_selected(file: String):
 	emit_signal("path_selected", file)
 
 func _on_visibility_changed():
-	if not visible:
+	if not _n_filesystem_popup.visible:
 		emit_signal("path_selected", "")
 
 func filesystem_filters(filters: Array = []):


### PR DESCRIPTION
Fixes #380.

The file picker wasn't actually emitting a signal if the user canceled selection, so any code that awaited for it, did so indefinitely.

Additionally solved accessibility focus issues with the new game media option on the first time popup.