### PR TITLE
Fix crash on picking game media folder on Windows due to null directory

### DIFF
--- a/scenes/popups/first_time/GamesSection.gd
+++ b/scenes/popups/first_time/GamesSection.gd
@@ -51,6 +51,9 @@ func check_empty_media():
 		n_media_warning_empty.visible = false
 		return
 	var dir := DirAccess.open(n_media_path.text)
+	if not dir:
+		n_media_warning_empty.visible = true
+		return
 	dir.include_navigational = false
 	n_media_warning_empty.visible = not (dir.get_files().is_empty() and dir.get_directories().is_empty())
 


### PR DESCRIPTION
It appears that opening an invalid directory on Windows returns a `null` instance, unlike on Linux. Because this is not tested explicitly, it then crashes due to dereferencing it. This check prevents this on Windows.